### PR TITLE
Update travis notification url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -178,6 +178,6 @@ script:
 notifications:
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/e09ccdce1048c5e03445
+      - https://webhooks.gitter.im/e/a513fc5759b168761b82
     on_success: change
     on_failure: always

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Official golang implementation of the Ethereum protocol.
 [![API Reference](
 https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667
 )](https://godoc.org/github.com/ethereum/go-ethereum)
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ethereum/go-ethereum?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/amisbft/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Automated builds are available for stable releases and the unstable master branch.
 Binary archives are published at https://geth.ethereum.org/downloads/.


### PR DESCRIPTION
Need to remove it when we send PR to official go-ethereum