### PR TITLE
consensus/pbft: replace gob with rlp

### DIFF
--- a/consensus/pbft/backends/simple/backend.go
+++ b/consensus/pbft/backends/simple/backend.go
@@ -19,6 +19,7 @@ package simple
 import (
 	"bytes"
 	"crypto/ecdsa"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -124,10 +125,9 @@ func (sb *simpleBackend) Commit(proposal *pbft.Proposal) error {
 	// step1: update validator set from extra data of block
 	// step2: insert chain
 	block := &types.Block{}
-	err := rlp.DecodeBytes(proposal.BlockContext.Payload(), block)
-	if err != nil {
-		sb.logger.Warn("decode block error", "err", err)
-		return err
+	block, ok := proposal.BlockContext.(*types.Block)
+	if !ok {
+		return fmt.Errorf("failed to decode block...")
 	}
 	// it's a proposer
 	if sb.commit != nil {
@@ -178,10 +178,9 @@ func (sb *simpleBackend) EventMux() *event.TypeMux {
 func (sb *simpleBackend) Verify(proposal *pbft.Proposal) error {
 	// decode the proposal to block
 	block := &types.Block{}
-	err := rlp.DecodeBytes(proposal.BlockContext.Payload(), block)
-	if err != nil {
-		log.Warn("decode block error", "err", err)
-		return err
+	block, ok := proposal.BlockContext.(*types.Block)
+	if !ok {
+		return fmt.Errorf("failed to decode block...")
 	}
 	// verify the header of proposed block
 	return sb.VerifyHeader(sb.chain, block.Header(), false)

--- a/consensus/pbft/backends/simple/backend.go
+++ b/consensus/pbft/backends/simple/backend.go
@@ -19,7 +19,6 @@ package simple
 import (
 	"bytes"
 	"crypto/ecdsa"
-	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -127,9 +126,8 @@ func (sb *simpleBackend) Commit(proposal *pbft.Proposal) error {
 	block := &types.Block{}
 	block, ok := proposal.RequestContext.(*types.Block)
 	if !ok {
-		errStr := "Failed to commit proposal since RequestContext cannot cast to *types.Block"
-		sb.logger.Error(errStr)
-		return fmt.Errorf(errStr)
+		sb.logger.Error("Failed to commit proposal since RequestContext cannot cast to *types.Block")
+		return errCastingRequest
 	}
 	// it's a proposer
 	if sb.commit != nil {
@@ -182,9 +180,8 @@ func (sb *simpleBackend) Verify(proposal *pbft.Proposal) error {
 	block := &types.Block{}
 	block, ok := proposal.RequestContext.(*types.Block)
 	if !ok {
-		errStr := "Failed to commit proposal since RequestContext cannot cast to *types.Block"
-		sb.logger.Error(errStr)
-		return fmt.Errorf(errStr)
+		sb.logger.Error("Failed to commit proposal since RequestContext cannot cast to *types.Block")
+		return errCastingRequest
 	}
 	// verify the header of proposed block
 	return sb.VerifyHeader(sb.chain, block.Header(), false)

--- a/consensus/pbft/backends/simple/backend.go
+++ b/consensus/pbft/backends/simple/backend.go
@@ -125,7 +125,7 @@ func (sb *simpleBackend) Commit(proposal *pbft.Proposal) error {
 	// step1: update validator set from extra data of block
 	// step2: insert chain
 	block := &types.Block{}
-	block, ok := proposal.BlockContext.(*types.Block)
+	block, ok := proposal.RequestContext.(*types.Block)
 	if !ok {
 		return fmt.Errorf("failed to decode block...")
 	}
@@ -178,7 +178,7 @@ func (sb *simpleBackend) EventMux() *event.TypeMux {
 func (sb *simpleBackend) Verify(proposal *pbft.Proposal) error {
 	// decode the proposal to block
 	block := &types.Block{}
-	block, ok := proposal.BlockContext.(*types.Block)
+	block, ok := proposal.RequestContext.(*types.Block)
 	if !ok {
 		return fmt.Errorf("failed to decode block...")
 	}

--- a/consensus/pbft/backends/simple/backend.go
+++ b/consensus/pbft/backends/simple/backend.go
@@ -121,13 +121,15 @@ func (sb *simpleBackend) Broadcast(payload []byte) error {
 
 // Commit implements pbft.Backend.Commit
 func (sb *simpleBackend) Commit(proposal *pbft.Proposal) error {
-	log.Info("Committed", "address", sb.Address().Hex(), "proposal", proposal)
+	sb.logger.Info("Committed", "address", sb.Address().Hex(), "proposal", proposal)
 	// step1: update validator set from extra data of block
 	// step2: insert chain
 	block := &types.Block{}
 	block, ok := proposal.RequestContext.(*types.Block)
 	if !ok {
-		return fmt.Errorf("failed to decode block...")
+		errStr := "Failed to commit proposal since RequestContext cannot cast to *types.Block"
+		sb.logger.Error(errStr)
+		return fmt.Errorf(errStr)
 	}
 	// it's a proposer
 	if sb.commit != nil {
@@ -180,7 +182,9 @@ func (sb *simpleBackend) Verify(proposal *pbft.Proposal) error {
 	block := &types.Block{}
 	block, ok := proposal.RequestContext.(*types.Block)
 	if !ok {
-		return fmt.Errorf("failed to decode block...")
+		errStr := "Failed to commit proposal since RequestContext cannot cast to *types.Block"
+		sb.logger.Error(errStr)
+		return fmt.Errorf(errStr)
 	}
 	// verify the header of proposed block
 	return sb.VerifyHeader(sb.chain, block.Header(), false)

--- a/consensus/pbft/backends/simple/engine.go
+++ b/consensus/pbft/backends/simple/engine.go
@@ -296,13 +296,9 @@ func (sb *simpleBackend) Seal(chain consensus.ChainReader, block *types.Block, s
 	}
 	copy(header.Extra[len(header.Extra)-extraSeal:], sighash)
 	block = block.WithSeal(header)
-	// step 2. feed block into PBFT engine
-	b, e := rlp.EncodeToBytes(block)
-	if e != nil {
-		return nil, e
-	}
+	// step 2. post block into PBFT engine
 	go sb.EventMux().Post(pbft.RequestEvent{
-		BlockContext: pbft.NewBlockContext(b, block.Number()),
+		BlockContext: block,
 	})
 
 	for {

--- a/consensus/pbft/backends/simple/engine.go
+++ b/consensus/pbft/backends/simple/engine.go
@@ -21,6 +21,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -301,6 +302,8 @@ func (sb *simpleBackend) Seal(chain consensus.ChainReader, block *types.Block, s
 		BlockContext: block,
 	})
 
+	// compensation for a few milliseconds of consensus runtime
+	<-time.After(100 * time.Millisecond)
 	for {
 		select {
 		case needNewProposal := <-sb.viewChange:

--- a/consensus/pbft/backends/simple/engine.go
+++ b/consensus/pbft/backends/simple/engine.go
@@ -67,6 +67,9 @@ var (
 var (
 	defaultDifficulty = big.NewInt(1)
 	nilUncleHash      = types.CalcUncleHash(nil) // Always Keccak256(RLP([])) as uncles are meaningless outside of PoW.
+
+	// Default minimum difference between two consecutive block's timestamps
+	blockPeriod = 100 * time.Millisecond
 )
 
 // Author retrieves the Ethereum address of the account that minted the given
@@ -293,7 +296,7 @@ func (sb *simpleBackend) Seal(chain consensus.ChainReader, block *types.Block, s
 
 	// TODO: config delay time, like PoA
 	// compensation for a few milliseconds of consensus runtime
-	<-time.After(100 * time.Millisecond)
+	<-time.After(blockPeriod)
 
 	// step 1. sign the hash
 	header := block.Header()

--- a/consensus/pbft/backends/simple/engine.go
+++ b/consensus/pbft/backends/simple/engine.go
@@ -289,6 +289,10 @@ func (sb *simpleBackend) Seal(chain consensus.ChainReader, block *types.Block, s
 	sb.newChannels()
 	defer sb.closeChannels()
 
+	// TODO: config delay time, like PoA
+	// compensation for a few milliseconds of consensus runtime
+	<-time.After(100 * time.Millisecond)
+
 	// step 1. sign the hash
 	header := block.Header()
 	sighash, err := sb.Sign(sigHash(header).Bytes())
@@ -302,8 +306,6 @@ func (sb *simpleBackend) Seal(chain consensus.ChainReader, block *types.Block, s
 		BlockContext: block,
 	})
 
-	// compensation for a few milliseconds of consensus runtime
-	<-time.After(100 * time.Millisecond)
 	for {
 		select {
 		case needNewProposal := <-sb.viewChange:

--- a/consensus/pbft/backends/simple/engine.go
+++ b/consensus/pbft/backends/simple/engine.go
@@ -61,6 +61,8 @@ var (
 	errInvalidUncleHash = errors.New("non empty uncle hash")
 	// errInconsistentValidatorSet is returned if the validator set is inconsistent
 	errInconsistentValidatorSet = errors.New("non empty uncle hash")
+	// errCastingRequest is returned if request cannot cast specific type
+	errCastingRequest = errors.New("failed to cast the request")
 )
 var (
 	defaultDifficulty = big.NewInt(1)

--- a/consensus/pbft/core/backlog.go
+++ b/consensus/pbft/core/backlog.go
@@ -86,15 +86,17 @@ func (c *core) storeBacklog(msg *message, src pbft.Validator) {
 	}
 	switch msg.Code {
 	case msgPreprepare:
-		m, ok := msg.Msg.(*pbft.Preprepare)
-		if ok {
-			backlog.Push(msg, toPriority(msg.Code, m.View))
+		var p *pbft.Preprepare
+		err := msg.Decode(&p)
+		if err == nil {
+			backlog.Push(msg, toPriority(msg.Code, p.View))
 		}
 		// for pbft.MsgPrepare and pbft.MsgCommit cases
 	default:
-		sub, ok := msg.Msg.(*pbft.Subject)
-		if ok {
-			backlog.Push(msg, toPriority(msg.Code, sub.View))
+		var p *pbft.Subject
+		err := msg.Decode(&p)
+		if err == nil {
+			backlog.Push(msg, toPriority(msg.Code, p.View))
 		}
 	}
 	c.backlogs[src] = backlog
@@ -121,14 +123,16 @@ func (c *core) processBacklog() {
 			var view *pbft.View
 			switch msg.Code {
 			case msgPreprepare:
-				m, ok := msg.Msg.(*pbft.Preprepare)
-				if ok {
+				var m *pbft.Preprepare
+				err := msg.Decode(&m)
+				if err == nil {
 					view = m.View
 				}
 				// for pbft.MsgPrepare and pbft.MsgCommit cases
 			default:
-				sub, ok := msg.Msg.(*pbft.Subject)
-				if ok {
+				var sub *pbft.Subject
+				err := msg.Decode(&sub)
+				if err == nil {
 					view = sub.View
 				}
 			}

--- a/consensus/pbft/core/backlog_test.go
+++ b/consensus/pbft/core/backlog_test.go
@@ -111,7 +111,7 @@ func TestStoreBacklog(t *testing.T) {
 				ParentHash: common.HexToHash("0x1234567890"),
 				DataHash:   common.HexToHash("0x9876543210"),
 			},
-			BlockContext: makeBlock(1),
+			RequestContext: makeBlock(1),
 			Signatures:   [][]byte{[]byte("sig1")},
 		},
 	}
@@ -208,7 +208,7 @@ func TestProcessBacklog(t *testing.T) {
 				ParentHash: common.HexToHash("0x1234567890"),
 				DataHash:   common.HexToHash("0x9876543210"),
 			},
-			BlockContext: makeBlock(1),
+			RequestContext: makeBlock(1),
 			Signatures:   [][]byte{[]byte("sig1")},
 		},
 	}

--- a/consensus/pbft/core/backlog_test.go
+++ b/consensus/pbft/core/backlog_test.go
@@ -115,9 +115,10 @@ func TestStoreBacklog(t *testing.T) {
 			Signatures:   [][]byte{[]byte("sig1")},
 		},
 	}
+	prepreparePayload, _ := Encode(preprepare)
 	m := &message{
 		Code: msgPreprepare,
-		Msg:  preprepare,
+		Msg:  prepreparePayload,
 	}
 	c.storeBacklog(m, p)
 	if !reflect.DeepEqual(c.backlogs[p].PopItem(), m) {
@@ -129,9 +130,11 @@ func TestStoreBacklog(t *testing.T) {
 		View:   v,
 		Digest: []byte("digest"),
 	}
+	subjectPayload, _ := Encode(subject)
+
 	m = &message{
 		Code: msgPrepare,
-		Msg:  subject,
+		Msg:  subjectPayload,
 	}
 	c.storeBacklog(m, p)
 	if !reflect.DeepEqual(c.backlogs[p].PopItem(), m) {
@@ -141,7 +144,7 @@ func TestStoreBacklog(t *testing.T) {
 	// push commit msg
 	m = &message{
 		Code: msgCommit,
-		Msg:  subject,
+		Msg:  subjectPayload,
 	}
 	c.storeBacklog(m, p)
 	if !reflect.DeepEqual(c.backlogs[p].PopItem(), m) {
@@ -173,9 +176,10 @@ func TestProcessFutureBacklog(t *testing.T) {
 		View:   v,
 		Digest: []byte("digest"),
 	}
+	subjectPayload, _ := Encode(subject)
 	m := &message{
 		Code: msgCommit,
-		Msg:  subject,
+		Msg:  subjectPayload,
 	}
 	c.storeBacklog(m, p)
 	c.processBacklog()
@@ -208,23 +212,26 @@ func TestProcessBacklog(t *testing.T) {
 			Signatures:   [][]byte{[]byte("sig1")},
 		},
 	}
+	prepreparePayload, _ := Encode(preprepare)
+
 	subject := &pbft.Subject{
 		View:   v,
 		Digest: []byte("digest"),
 	}
+	subjectPayload, _ := Encode(subject)
 
 	msgs := []*message{
 		&message{
 			Code: msgPreprepare,
-			Msg:  preprepare,
+			Msg:  prepreparePayload,
 		},
 		&message{
 			Code: msgPrepare,
-			Msg:  subject,
+			Msg:  subjectPayload,
 		},
 		&message{
 			Code: msgCommit,
-			Msg:  subject,
+			Msg:  subjectPayload,
 		},
 	}
 	for i := 0; i < len(msgs); i++ {

--- a/consensus/pbft/core/backlog_test.go
+++ b/consensus/pbft/core/backlog_test.go
@@ -111,7 +111,7 @@ func TestStoreBacklog(t *testing.T) {
 				ParentHash: common.HexToHash("0x1234567890"),
 				DataHash:   common.HexToHash("0x9876543210"),
 			},
-			BlockContext: pbft.NewBlockContext([]byte("payload"), big.NewInt(1)),
+			BlockContext: makeBlock(1),
 			Signatures:   [][]byte{[]byte("sig1")},
 		},
 	}
@@ -208,7 +208,7 @@ func TestProcessBacklog(t *testing.T) {
 				ParentHash: common.HexToHash("0x1234567890"),
 				DataHash:   common.HexToHash("0x9876543210"),
 			},
-			BlockContext: pbft.NewBlockContext([]byte("payload"), big.NewInt(1)),
+			BlockContext: makeBlock(1),
 			Signatures:   [][]byte{[]byte("sig1")},
 		},
 	}

--- a/consensus/pbft/core/checkpoint.go
+++ b/consensus/pbft/core/checkpoint.go
@@ -29,6 +29,7 @@ func (c *core) sendCheckpoint(cp *pbft.Subject) {
 	newCp, err := Encode(cp)
 	if err != nil {
 		logger.Error("Failed to encode", "subject", cp)
+		return
 	}
 
 	c.broadcast(&message{

--- a/consensus/pbft/core/checkpoint.go
+++ b/consensus/pbft/core/checkpoint.go
@@ -25,17 +25,24 @@ import (
 func (c *core) sendCheckpoint(cp *pbft.Subject) {
 	logger := c.logger.New("state", c.state)
 	logger.Debug("sendCheckpoint")
+
+	newCp, err := Encode(cp)
+	if err != nil {
+		logger.Error("Failed to encode...")
+	}
+
 	c.broadcast(&message{
 		Code: msgCheckpoint,
-		Msg:  cp,
+		Msg:  newCp,
 	})
 }
 
 func (c *core) handleCheckpoint(msg *message, src pbft.Validator) error {
 	logger := c.logger.New("from", src.Address().Hex(), "state", c.state)
 
-	cp, ok := msg.Msg.(*pbft.Subject)
-	if !ok {
+	var cp *pbft.Subject
+	err := msg.Decode(&cp)
+	if err != nil {
 		logger.Error("Invalid checkpoint message", "msg", msg)
 		return pbft.ErrInvalidMessage
 	}

--- a/consensus/pbft/core/checkpoint.go
+++ b/consensus/pbft/core/checkpoint.go
@@ -28,7 +28,7 @@ func (c *core) sendCheckpoint(cp *pbft.Subject) {
 
 	newCp, err := Encode(cp)
 	if err != nil {
-		logger.Error("Failed to encode...")
+		logger.Error("Failed to encode", "subject", cp)
 	}
 
 	c.broadcast(&message{

--- a/consensus/pbft/core/commit.go
+++ b/consensus/pbft/core/commit.go
@@ -25,9 +25,14 @@ import (
 func (c *core) sendCommit() {
 	logger := c.logger.New("state", c.state)
 	logger.Debug("sendCommit")
+
+	subject, err := Encode(c.subject)
+	if err != nil {
+		logger.Error("Failed to encode...")
+	}
 	c.broadcast(&message{
 		Code: msgCommit,
-		Msg:  c.subject,
+		Msg:  subject,
 	})
 }
 
@@ -35,8 +40,9 @@ func (c *core) handleCommit(msg *message, src pbft.Validator) error {
 	logger := c.logger.New("from", src.Address().Hex(), "state", c.state)
 	logger.Debug("handleCommit")
 
-	commit, ok := msg.Msg.(*pbft.Subject)
-	if !ok {
+	var commit *pbft.Subject
+	err := msg.Decode(&commit)
+	if err != nil {
 		return errFailedDecodeCommit
 	}
 

--- a/consensus/pbft/core/commit.go
+++ b/consensus/pbft/core/commit.go
@@ -29,6 +29,7 @@ func (c *core) sendCommit() {
 	subject, err := Encode(c.subject)
 	if err != nil {
 		logger.Error("Failed to encode", "subject", c.subject)
+		return
 	}
 	c.broadcast(&message{
 		Code: msgCommit,

--- a/consensus/pbft/core/commit.go
+++ b/consensus/pbft/core/commit.go
@@ -28,7 +28,7 @@ func (c *core) sendCommit() {
 
 	subject, err := Encode(c.subject)
 	if err != nil {
-		logger.Error("Failed to encode...")
+		logger.Error("Failed to encode", "subject", c.subject)
 	}
 	c.broadcast(&message{
 		Code: msgCommit,

--- a/consensus/pbft/core/commit_test.go
+++ b/consensus/pbft/core/commit_test.go
@@ -142,9 +142,10 @@ OUTER:
 
 		for i, v := range test.system.backends {
 			validator := v.Validators().GetByIndex(uint64(i))
+			m, _ := Encode(v.engine.(*core).subject)
 			if err := r0.handlePrepare(&message{
 				Code:    msgPrepare,
-				Msg:     v.engine.(*core).subject,
+				Msg:     m,
 				Address: validator.Address(),
 			}, validator); err != nil {
 				if err != test.expectedErr {

--- a/consensus/pbft/core/core.go
+++ b/consensus/pbft/core/core.go
@@ -163,8 +163,8 @@ func (c *core) makeProposal(seq *big.Int, request *pbft.Request) *pbft.Proposal 
 	}
 
 	return &pbft.Proposal{
-		Header:       header,
-		BlockContext: request.BlockContext,
+		Header:         header,
+		RequestContext: request.BlockContext,
 	}
 }
 

--- a/consensus/pbft/core/core.go
+++ b/consensus/pbft/core/core.go
@@ -158,8 +158,8 @@ func (c *core) makeProposal(seq *big.Int, request *pbft.Request) *pbft.Proposal 
 	header := &pbft.ProposalHeader{
 		Sequence: seq,
 		// FIXME: use actual parent hash
-		ParentHash: c.backend.Hash(request.BlockContext.Payload()),
-		DataHash:   c.backend.Hash(request.BlockContext.Payload()),
+		ParentHash: c.backend.Hash(request.BlockContext.Number()),
+		DataHash:   c.backend.Hash(request.BlockContext.Number()),
 	}
 
 	return &pbft.Proposal{

--- a/consensus/pbft/core/core_test.go
+++ b/consensus/pbft/core/core_test.go
@@ -67,10 +67,10 @@ func TestNewRequest(t *testing.T) {
 		if len(backend.commitMsgs) != 2 {
 			t.Error("expected execution of requests should be 2")
 		}
-		if !reflect.DeepEqual(request1.Number(), backend.commitMsgs[0].BlockContext.Number()) {
+		if !reflect.DeepEqual(request1.Number(), backend.commitMsgs[0].RequestContext.Number()) {
 			t.Error("payload is not the same (1)")
 		}
-		if !reflect.DeepEqual(request2.Number(), backend.commitMsgs[1].BlockContext.Number()) {
+		if !reflect.DeepEqual(request2.Number(), backend.commitMsgs[1].RequestContext.Number()) {
 			t.Error("payload is not the same (2)")
 		}
 	}

--- a/consensus/pbft/core/handler_test.go
+++ b/consensus/pbft/core/handler_test.go
@@ -49,7 +49,7 @@ func TestHandleMsg(t *testing.T) {
 				ParentHash: common.HexToHash("0x1234567890"),
 				DataHash:   common.HexToHash("0x9876543210"),
 			},
-			BlockContext: makeBlock(1),
+			RequestContext: makeBlock(1),
 			Signatures: [][]byte{
 				[]byte{0x01},
 				[]byte{0x02},
@@ -78,7 +78,7 @@ func TestHandleMsg(t *testing.T) {
 				ParentHash: common.HexToHash("0x1234567890"),
 				DataHash:   common.HexToHash("0x9876543210"),
 			},
-			BlockContext: makeBlock(2),
+			RequestContext: makeBlock(2),
 			Signatures: [][]byte{
 				[]byte{0x01},
 				[]byte{0x02},
@@ -107,7 +107,7 @@ func TestHandleMsg(t *testing.T) {
 				ParentHash: common.HexToHash("0x1234567890"),
 				DataHash:   common.HexToHash("0x9876543210"),
 			},
-			BlockContext: makeBlock(2),
+			RequestContext: makeBlock(2),
 			Signatures: [][]byte{
 				[]byte{0x01},
 				[]byte{0x02},

--- a/consensus/pbft/core/handler_test.go
+++ b/consensus/pbft/core/handler_test.go
@@ -49,7 +49,7 @@ func TestHandleMsg(t *testing.T) {
 				ParentHash: common.HexToHash("0x1234567890"),
 				DataHash:   common.HexToHash("0x9876543210"),
 			},
-			BlockContext: pbft.NewBlockContext([]byte{0x02}, big.NewInt(2)),
+			BlockContext: makeBlock(1),
 			Signatures: [][]byte{
 				[]byte{0x01},
 				[]byte{0x02},
@@ -78,7 +78,7 @@ func TestHandleMsg(t *testing.T) {
 				ParentHash: common.HexToHash("0x1234567890"),
 				DataHash:   common.HexToHash("0x9876543210"),
 			},
-			BlockContext: pbft.NewBlockContext([]byte{0x02}, big.NewInt(2)),
+			BlockContext: makeBlock(2),
 			Signatures: [][]byte{
 				[]byte{0x01},
 				[]byte{0x02},
@@ -107,7 +107,7 @@ func TestHandleMsg(t *testing.T) {
 				ParentHash: common.HexToHash("0x1234567890"),
 				DataHash:   common.HexToHash("0x9876543210"),
 			},
-			BlockContext: pbft.NewBlockContext([]byte{0x02}, big.NewInt(2)),
+			BlockContext: makeBlock(2),
 			Signatures: [][]byte{
 				[]byte{0x01},
 				[]byte{0x02},

--- a/consensus/pbft/core/handler_test.go
+++ b/consensus/pbft/core/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/consensus/pbft"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // notice: the normal case have been tested in integration tests.
@@ -19,16 +20,17 @@ func TestHandleMsg(t *testing.T) {
 	v0 := sys.backends[0]
 	r0 := v0.engine.(*core)
 
+	m, _ := Encode(&pbft.Subject{
+		View: &pbft.View{
+			Sequence:   big.NewInt(0),
+			ViewNumber: big.NewInt(0),
+		},
+		Digest: []byte{1},
+	})
 	// with a matched payload. msgPreprepare should match with *pbft.Preprepare in normal case.
 	msg := &message{
 		Code: msgPreprepare,
-		Msg: &pbft.Subject{
-			View: &pbft.View{
-				Sequence:   big.NewInt(0),
-				ViewNumber: big.NewInt(0),
-			},
-			Digest: []byte{1},
-		},
+		Msg: m,
 		Address: v0.Address(),
 	}
 
@@ -36,16 +38,28 @@ func TestHandleMsg(t *testing.T) {
 		t.Error("message should decode failed")
 	}
 
+	m, _ = Encode(&pbft.Preprepare{
+		View: &pbft.View{
+			Sequence:   big.NewInt(0),
+			ViewNumber: big.NewInt(0),
+		},
+		Proposal: &pbft.Proposal{
+			Header: &pbft.ProposalHeader{
+				Sequence:   big.NewInt(10),
+				ParentHash: common.HexToHash("0x1234567890"),
+				DataHash:   common.HexToHash("0x9876543210"),
+			},
+			BlockContext: pbft.NewBlockContext([]byte{0x02}, big.NewInt(2)),
+			Signatures: [][]byte{
+				[]byte{0x01},
+				[]byte{0x02},
+			},
+		},
+	})
 	// with a unmatched payload. msgPrepare should match with *pbft.Subject in normal case.
 	msg = &message{
 		Code: msgPrepare,
-		Msg: &pbft.Preprepare{
-			View: &pbft.View{
-				Sequence:   big.NewInt(0),
-				ViewNumber: big.NewInt(0),
-			},
-			Proposal: nil,
-		},
+		Msg: m,
 		Address: v0.Address(),
 	}
 
@@ -53,16 +67,28 @@ func TestHandleMsg(t *testing.T) {
 		t.Error("message should decode failed")
 	}
 
+	m, _ = Encode(&pbft.Preprepare{
+		View: &pbft.View{
+			Sequence:   big.NewInt(0),
+			ViewNumber: big.NewInt(0),
+		},
+		Proposal: &pbft.Proposal{
+			Header: &pbft.ProposalHeader{
+				Sequence:   big.NewInt(10),
+				ParentHash: common.HexToHash("0x1234567890"),
+				DataHash:   common.HexToHash("0x9876543210"),
+			},
+			BlockContext: pbft.NewBlockContext([]byte{0x02}, big.NewInt(2)),
+			Signatures: [][]byte{
+				[]byte{0x01},
+				[]byte{0x02},
+			},
+		},
+	})
 	// with a unmatched payload. pbft.MsgCommit should match with *pbft.Subject in normal case.
 	msg = &message{
 		Code: msgCommit,
-		Msg: &pbft.Preprepare{
-			View: &pbft.View{
-				Sequence:   big.NewInt(0),
-				ViewNumber: big.NewInt(0),
-			},
-			Proposal: nil,
-		},
+		Msg: m,
 		Address: v0.Address(),
 	}
 
@@ -70,16 +96,28 @@ func TestHandleMsg(t *testing.T) {
 		t.Error("message should decode failed")
 	}
 
+	m, _ = Encode(&pbft.Preprepare{
+		View: &pbft.View{
+			Sequence:   big.NewInt(0),
+			ViewNumber: big.NewInt(0),
+		},
+		Proposal: &pbft.Proposal{
+			Header: &pbft.ProposalHeader{
+				Sequence:   big.NewInt(10),
+				ParentHash: common.HexToHash("0x1234567890"),
+				DataHash:   common.HexToHash("0x9876543210"),
+			},
+			BlockContext: pbft.NewBlockContext([]byte{0x02}, big.NewInt(2)),
+			Signatures: [][]byte{
+				[]byte{0x01},
+				[]byte{0x02},
+			},
+		},
+	})
 	// invalid message code. message code is not exists in list
 	msg = &message{
 		Code: uint64(99),
-		Msg: &pbft.Preprepare{
-			View: &pbft.View{
-				Sequence:   big.NewInt(0),
-				ViewNumber: big.NewInt(0),
-			},
-			Proposal: nil,
-		},
+		Msg: m,
 		Address: v0.Address(),
 	}
 

--- a/consensus/pbft/core/prepare.go
+++ b/consensus/pbft/core/prepare.go
@@ -25,9 +25,14 @@ import (
 func (c *core) sendPrepare() {
 	logger := c.logger.New("state", c.state)
 	logger.Debug("sendPrepare")
+
+	subject, err := Encode(c.subject)
+	if err != nil {
+		logger.Error("Failed to encode...")
+	}
 	c.broadcast(&message{
 		Code: msgPrepare,
-		Msg:  c.subject,
+		Msg:  subject,
 	})
 }
 
@@ -35,8 +40,9 @@ func (c *core) handlePrepare(msg *message, src pbft.Validator) error {
 	logger := c.logger.New("from", src.Address().Hex(), "state", c.state)
 	logger.Debug("handlePrepare")
 
-	prepare, ok := msg.Msg.(*pbft.Subject)
-	if !ok {
+	var prepare *pbft.Subject
+	err := msg.Decode(&prepare)
+	if err != nil {
 		return errFailedDecodePrepare
 	}
 

--- a/consensus/pbft/core/prepare.go
+++ b/consensus/pbft/core/prepare.go
@@ -28,7 +28,7 @@ func (c *core) sendPrepare() {
 
 	subject, err := Encode(c.subject)
 	if err != nil {
-		logger.Error("Failed to encode...")
+		logger.Error("Failed to encode", "subject", c.subject)
 	}
 	c.broadcast(&message{
 		Code: msgPrepare,

--- a/consensus/pbft/core/prepare.go
+++ b/consensus/pbft/core/prepare.go
@@ -29,6 +29,7 @@ func (c *core) sendPrepare() {
 	subject, err := Encode(c.subject)
 	if err != nil {
 		logger.Error("Failed to encode", "subject", c.subject)
+		return
 	}
 	c.broadcast(&message{
 		Code: msgPrepare,

--- a/consensus/pbft/core/prepare_test.go
+++ b/consensus/pbft/core/prepare_test.go
@@ -143,9 +143,10 @@ OUTER:
 
 		for i, v := range test.system.backends {
 			validator := v.Validators().GetByIndex(uint64(i))
+			m, _ := Encode(v.engine.(*core).subject)
 			if err := r0.handlePrepare(&message{
 				Code:    msgPrepare,
-				Msg:     v.engine.(*core).subject,
+				Msg:     m,
 				Address: validator.Address(),
 			}, validator); err != nil {
 				if err != test.expectedErr {
@@ -188,8 +189,9 @@ OUTER:
 		if decodedMsg.Code != msgCommit {
 			t.Error("message code is not the same")
 		}
-		m, ok := decodedMsg.Msg.(*pbft.Subject)
-		if !ok {
+		var m *pbft.Subject
+		err = decodedMsg.Decode(&m)
+		if err != nil {
 			t.Error("failed to decode Prepare")
 		}
 		if !reflect.DeepEqual(m, expectedSubject) {

--- a/consensus/pbft/core/preprepare.go
+++ b/consensus/pbft/core/preprepare.go
@@ -33,13 +33,14 @@ func (c *core) sendPreprepare(request *pbft.Request) {
 			Proposal: c.makeProposal(nextSeqView.Sequence, request),
 		})
 		if err != nil {
-			logger.Error("Failed to encode...")
+			logger.Error("Failed to encode", "view", nextSeqView)
+			return
 		}
 
 		logger.Debug("sendPreprepare")
 		c.broadcast(&message{
 			Code: msgPreprepare,
-			Msg: preprepare,
+			Msg:  preprepare,
 		})
 	}
 }
@@ -50,7 +51,7 @@ func (c *core) handlePreprepare(msg *message, src pbft.Validator) error {
 
 	var preprepare *pbft.Preprepare
 	err := msg.Decode(&preprepare)
-	if err != nil  {
+	if err != nil {
 		return errFailedDecodePreprepare
 	}
 

--- a/consensus/pbft/core/preprepare_test.go
+++ b/consensus/pbft/core/preprepare_test.go
@@ -48,7 +48,7 @@ func TestHandlePreprepare(t *testing.T) {
 				}
 				return sys
 			}(),
-			pbft.NewBlockContext([]byte("normal case"), big.NewInt(1)),
+			makeBlock(1),
 			nil,
 		},
 		{
@@ -75,7 +75,7 @@ func TestHandlePreprepare(t *testing.T) {
 				}
 				return sys
 			}(),
-			pbft.NewBlockContext([]byte("future message"), big.NewInt(1)),
+			makeBlock(1),
 			errFutureMessage,
 		},
 		{
@@ -96,7 +96,7 @@ func TestHandlePreprepare(t *testing.T) {
 				}
 				return sys
 			}(),
-			pbft.NewBlockContext([]byte("not from proposer"), big.NewInt(1)),
+			makeBlock(1),
 			pbft.ErrNotFromProposer,
 		},
 		{
@@ -115,7 +115,7 @@ func TestHandlePreprepare(t *testing.T) {
 				}
 				return sys
 			}(),
-			pbft.NewBlockContext([]byte("invalid message"), big.NewInt(1)),
+			makeBlock(1),
 			pbft.ErrInvalidMessage,
 		},
 		{
@@ -134,7 +134,7 @@ func TestHandlePreprepare(t *testing.T) {
 				}
 				return sys
 			}(),
-			pbft.NewBlockContext([]byte("nil proposal"), big.NewInt(1)),
+			makeBlock(1),
 			pbft.ErrNilProposal,
 		},
 	}

--- a/consensus/pbft/core/preprepare_test.go
+++ b/consensus/pbft/core/preprepare_test.go
@@ -30,7 +30,7 @@ func TestHandlePreprepare(t *testing.T) {
 
 	testCases := []struct {
 		system          *testSystem
-		expectedRequest pbft.BlockContexter
+		expectedRequest pbft.RequestContexter
 
 		expectedErr error
 	}{

--- a/consensus/pbft/core/testbackend_test.go
+++ b/consensus/pbft/core/testbackend_test.go
@@ -130,7 +130,7 @@ func (self *testSystemBackend) Decode([]byte, interface{}) error {
 	return nil
 }
 
-func (self *testSystemBackend) NewRequest(request pbft.BlockContexter) {
+func (self *testSystemBackend) NewRequest(request pbft.RequestContexter) {
 	go self.events.Post(pbft.RequestEvent{
 		BlockContext: request,
 	})

--- a/consensus/pbft/core/types.go
+++ b/consensus/pbft/core/types.go
@@ -44,7 +44,7 @@ type message struct {
 //
 // define the functions that needs to be provided for rlp Encoder/Decoder.
 
-// EncodeRLP serializes b into the Ethereum RLP View format.
+// EncodeRLP serializes m into the Ethereum RLP format.
 func (m *message) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, []interface{}{m.Code, m.Msg, m.Address, m.Signature})
 }

--- a/consensus/pbft/core/types_test.go
+++ b/consensus/pbft/core/types_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func testPreprepare(t *testing.T) {
+	block := makeBlock(1)
 	pp := &pbft.Preprepare{
 		View: &pbft.View{
 			ViewNumber: big.NewInt(1),
@@ -37,7 +38,7 @@ func testPreprepare(t *testing.T) {
 				ParentHash: common.HexToHash("0x1234567890"),
 				DataHash:   common.HexToHash("0x9876543210"),
 			},
-			BlockContext: pbft.NewBlockContext([]byte{0x02}, big.NewInt(2)),
+			BlockContext: block,
 			Signatures: [][]byte{
 				[]byte{0x01},
 				[]byte{0x02},
@@ -69,8 +70,22 @@ func testPreprepare(t *testing.T) {
 		t.Error(err)
 	}
 
-	if !reflect.DeepEqual(pp, decodedPP) {
-		t.Errorf("messages are different, expected '%+v', got '%+v'", pp, decodedPP)
+	// if block is encoded/decoded by rlp, we cannot to compare interface data type using reflect.DeepEqual. (like BlockContext)
+	// so individual comparison here.
+	if !reflect.DeepEqual(pp.Proposal.Header, decodedPP.Proposal.Header) {
+		t.Errorf("Header are different, expected '%+v', got '%+v'", pp.Proposal, decodedPP.Proposal)
+	}
+
+	if !reflect.DeepEqual(pp.Proposal.Signatures, decodedPP.Proposal.Signatures) {
+		t.Errorf("Signatures are different, expected '%+v', got '%+v'", pp.Proposal.Signatures, decodedPP.Proposal.Signatures)
+	}
+
+	if !reflect.DeepEqual(pp.View, decodedPP.View) {
+		t.Errorf("View are different, expected '%+v', got '%+v'", pp.View, decodedPP.View)
+	}
+
+	if !reflect.DeepEqual(pp.Proposal.BlockContext.Number(), decodedPP.Proposal.BlockContext.Number()) {
+		t.Errorf("Block number are different, expected '%+v', got '%+v'", pp, decodedPP)
 	}
 }
 

--- a/consensus/pbft/core/types_test.go
+++ b/consensus/pbft/core/types_test.go
@@ -38,7 +38,7 @@ func testPreprepare(t *testing.T) {
 				ParentHash: common.HexToHash("0x1234567890"),
 				DataHash:   common.HexToHash("0x9876543210"),
 			},
-			BlockContext: block,
+			RequestContext: block,
 			Signatures: [][]byte{
 				[]byte{0x01},
 				[]byte{0x02},
@@ -84,7 +84,7 @@ func testPreprepare(t *testing.T) {
 		t.Errorf("View are different, expected '%+v', got '%+v'", pp.View, decodedPP.View)
 	}
 
-	if !reflect.DeepEqual(pp.Proposal.BlockContext.Number(), decodedPP.Proposal.BlockContext.Number()) {
+	if !reflect.DeepEqual(pp.Proposal.RequestContext.Number(), decodedPP.Proposal.RequestContext.Number()) {
 		t.Errorf("Block number are different, expected '%+v', got '%+v'", pp, decodedPP)
 	}
 }

--- a/consensus/pbft/core/types_test.go
+++ b/consensus/pbft/core/types_test.go
@@ -44,10 +44,11 @@ func testPreprepare(t *testing.T) {
 			},
 		},
 	}
+	prepreparePayload, _ := Encode(pp)
 
 	m := &message{
 		Code:    msgPreprepare,
-		Msg:     pp,
+		Msg:     prepreparePayload,
 		Address: common.HexToAddress("0x1234567890"),
 	}
 
@@ -63,7 +64,7 @@ func testPreprepare(t *testing.T) {
 	}
 
 	var decodedPP *pbft.Preprepare
-	decodedPP = decodedMsg.Msg.(*pbft.Preprepare)
+	err = decodedMsg.Decode(&decodedPP)
 	if err != nil {
 		t.Error(err)
 	}
@@ -82,9 +83,11 @@ func testSubject(t *testing.T) {
 		Digest: []byte{0x01, 0x02},
 	}
 
+	subjectPayload, _ := Encode(s)
+
 	m := &message{
 		Code:    msgPreprepare,
-		Msg:     s,
+		Msg:     subjectPayload,
 		Address: common.HexToAddress("0x1234567890"),
 	}
 
@@ -100,7 +103,7 @@ func testSubject(t *testing.T) {
 	}
 
 	var decodedSub *pbft.Subject
-	decodedSub = decodedMsg.Msg.(*pbft.Subject)
+	err = decodedMsg.Decode(&decodedSub)
 	if err != nil {
 		t.Error(err)
 	}
@@ -120,10 +123,11 @@ func testWithSignature(t *testing.T) {
 	}
 	expectedSig := []byte{0x01}
 
+	subjectPayload, _ := Encode(s)
 	// 1. Encode test
 	m := &message{
 		Code:      msgPreprepare,
-		Msg:       s,
+		Msg:       subjectPayload,
 		Address:   common.HexToAddress("0x1234567890"),
 		Signature: expectedSig,
 	}

--- a/consensus/pbft/events.go
+++ b/consensus/pbft/events.go
@@ -30,7 +30,7 @@ type ConsensusDataEvent struct {
 }
 
 type RequestEvent struct {
-	BlockContext BlockContexter
+	BlockContext RequestContexter
 }
 
 type ConnectionEvent struct {

--- a/consensus/pbft/message_set_test.go
+++ b/consensus/pbft/message_set_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-
 	set "gopkg.in/fatih/set.v0"
 )
 

--- a/consensus/pbft/message_set_test.go
+++ b/consensus/pbft/message_set_test.go
@@ -22,9 +22,22 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	set "gopkg.in/fatih/set.v0"
 )
+
+func makeBlock(number int64) *types.Block {
+	header := &types.Header{
+		Difficulty: big.NewInt(0),
+		Number:     big.NewInt(number),
+		GasLimit:   big.NewInt(0),
+		GasUsed:    big.NewInt(0),
+		Time:       big.NewInt(0),
+	}
+	block := &types.Block{}
+	return block.WithSeal(header)
+}
 
 func TestMessageSetWithPreprepare(t *testing.T) {
 	view := &View{
@@ -45,7 +58,7 @@ func TestMessageSetWithPreprepare(t *testing.T) {
 				ParentHash: common.HexToHash("0x1234567890"),
 				DataHash:   common.HexToHash("0x9876543210"),
 			},
-			BlockContext: NewBlockContext([]byte{0x02}, big.NewInt(2)),
+			BlockContext: makeBlock(1),
 			Signatures: [][]byte{
 				[]byte{0x01, 0x03},
 				[]byte{0x02, 0x04},
@@ -120,7 +133,7 @@ func TestMessageSetWithSubject(t *testing.T) {
 				ParentHash: common.HexToHash("0x1234567890"),
 				DataHash:   common.HexToHash("0x9876543210"),
 			},
-			BlockContext: NewBlockContext([]byte{0x02}, big.NewInt(2)),
+			BlockContext: makeBlock(1),
 			Signatures: [][]byte{
 				[]byte{0x01, 0x03},
 				[]byte{0x02, 0x04},

--- a/consensus/pbft/message_set_test.go
+++ b/consensus/pbft/message_set_test.go
@@ -58,7 +58,7 @@ func TestMessageSetWithPreprepare(t *testing.T) {
 				ParentHash: common.HexToHash("0x1234567890"),
 				DataHash:   common.HexToHash("0x9876543210"),
 			},
-			BlockContext: makeBlock(1),
+			RequestContext: makeBlock(1),
 			Signatures: [][]byte{
 				[]byte{0x01, 0x03},
 				[]byte{0x02, 0x04},
@@ -133,7 +133,7 @@ func TestMessageSetWithSubject(t *testing.T) {
 				ParentHash: common.HexToHash("0x1234567890"),
 				DataHash:   common.HexToHash("0x9876543210"),
 			},
-			BlockContext: makeBlock(1),
+			RequestContext: makeBlock(1),
 			Signatures: [][]byte{
 				[]byte{0x01, 0x03},
 				[]byte{0x02, 0x04},

--- a/consensus/pbft/types.go
+++ b/consensus/pbft/types.go
@@ -36,7 +36,7 @@ type State struct {
 // BlockContexter supports retrieving height and serialized block to be used during PBFT consensus.
 type BlockContexter interface {
 	// Number retrieves block height.
-	Height() *big.Int
+	Number() *big.Int
 
 	// Payload returns a serialized block
 	Payload() []byte
@@ -48,21 +48,21 @@ type BlockContexter interface {
 // TODO: Wrapper is not needed.
 // We wrap the block by BlockContext struct since the gob cannot encode/decode private fields (like types.Block.header).
 // So a custom encoder/decoder is needed. The go-ethereum rlp encoder/decoder is recommended here.
-func NewBlockContext(payload []byte, number *big.Int) *BlockContext {
+func NewBlockContext(payload []byte, height *big.Int) *BlockContext {
 	return &BlockContext{
 		RawData: payload,
-		Number:  number,
+		Height:  height,
 	}
 }
 
 // BlockContext expose their members which allow the struct can be marshal/unmarshal by gob.
 type BlockContext struct {
 	RawData []byte
-	Number  *big.Int
+	Height  *big.Int
 }
 
-func (b *BlockContext) Height() *big.Int {
-	return b.Number
+func (b *BlockContext) Number() *big.Int {
+	return b.Height
 }
 
 func (b *BlockContext) Payload() []byte {

--- a/consensus/pbft/types.go
+++ b/consensus/pbft/types.go
@@ -35,7 +35,7 @@ type State struct {
 }
 
 // BlockContexter supports retrieving height and serialized block to be used during PBFT consensus.
-type BlockContexter interface {
+type RequestContexter interface {
 	// Number retrieves block height.
 	Number() *big.Int
 
@@ -45,7 +45,7 @@ type BlockContexter interface {
 }
 
 type Request struct {
-	BlockContext BlockContexter
+	BlockContext RequestContexter
 }
 
 type View struct {
@@ -60,28 +60,28 @@ type ProposalHeader struct {
 }
 
 type Proposal struct {
-	Header       *ProposalHeader
-	BlockContext BlockContexter
-	Signatures   [][]byte
+	Header         *ProposalHeader
+	RequestContext RequestContexter
+	Signatures     [][]byte
 }
 
 // EncodeRLP serializes b into the Ethereum RLP View format.
 func (b *Proposal) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{b.Header, b.BlockContext, b.Signatures})
+	return rlp.Encode(w, []interface{}{b.Header, b.RequestContext, b.Signatures})
 }
 
 // DecodeRLP implements rlp.Decoder, and load the consensus fields from a RLP stream.
 func (b *Proposal) DecodeRLP(s *rlp.Stream) error {
 	var proposal struct {
-		Header       *ProposalHeader
-		BlockContext *types.Block
-		Signatures   [][]byte
+		Header         *ProposalHeader
+		RequestContext *types.Block
+		Signatures     [][]byte
 	}
 
 	if err := s.Decode(&proposal); err != nil {
 		return err
 	}
-	b.Header, b.BlockContext, b.Signatures = proposal.Header, proposal.BlockContext, proposal.Signatures
+	b.Header, b.RequestContext, b.Signatures = proposal.Header, proposal.RequestContext, proposal.Signatures
 	return nil
 }
 

--- a/consensus/pbft/types.go
+++ b/consensus/pbft/types.go
@@ -36,8 +36,11 @@ type State struct {
 
 // BlockContexter supports retrieving height and serialized block to be used during PBFT consensus.
 type RequestContexter interface {
-	// Number retrieves block height.
+	// Number retrieves number of sequence.
 	Number() *big.Int
+
+	// Hash retrieves hash of request.
+	Hash() common.Hash
 
 	EncodeRLP(w io.Writer) error
 
@@ -65,7 +68,7 @@ type Proposal struct {
 	Signatures     [][]byte
 }
 
-// EncodeRLP serializes b into the Ethereum RLP View format.
+// EncodeRLP serializes b into the Ethereum RLP format.
 func (b *Proposal) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, []interface{}{b.Header, b.RequestContext, b.Signatures})
 }
@@ -90,7 +93,7 @@ type Preprepare struct {
 	Proposal *Proposal
 }
 
-// EncodeRLP serializes b into the Ethereum RLP View format.
+// EncodeRLP serializes b into the Ethereum RLP format.
 func (b *Preprepare) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, []interface{}{b.View, b.Proposal})
 }
@@ -115,7 +118,7 @@ type Subject struct {
 	Digest []byte
 }
 
-// EncodeRLP serializes b into the Ethereum RLP View format.
+// EncodeRLP serializes b into the Ethereum RLP format.
 func (b *Subject) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, []interface{}{b.View, b.Digest})
 }
@@ -141,7 +144,7 @@ type ViewChange struct {
 	Proposal   *Proposal
 }
 
-// EncodeRLP serializes b into the Ethereum RLP View format.
+// EncodeRLP serializes b into the Ethereum RLP format.
 func (b *ViewChange) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, []interface{}{b.ViewNumber, b.PSet, b.QSet, b.Proposal})
 }
@@ -174,7 +177,7 @@ type NewView struct {
 	Proposal   *Proposal
 }
 
-// EncodeRLP serializes b into the Ethereum RLP View format.
+// EncodeRLP serializes b into the Ethereum RLP format.
 func (b *NewView) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, []interface{}{b.ViewNumber, b.VSet, b.XSet, b.Proposal})
 }
@@ -193,10 +196,4 @@ func (b *NewView) DecodeRLP(s *rlp.Stream) error {
 	}
 	b.ViewNumber, b.VSet, b.XSet, b.Proposal = newView.ViewNumber, newView.VSet, newView.XSet, newView.Proposal
 	return nil
-}
-
-type Checkpoint struct {
-	Sequence  *big.Int
-	Digest    []byte
-	Signature []byte
 }

--- a/consensus/pbft/types.go
+++ b/consensus/pbft/types.go
@@ -40,6 +40,10 @@ type BlockContexter interface {
 
 	// Payload returns a serialized block
 	Payload() []byte
+
+	EncodeRLP(w io.Writer) error
+
+	DecodeRLP(s *rlp.Stream) error
 }
 
 // NewBlockContext returns a BlockContext using the given payload and number.
@@ -67,6 +71,23 @@ func (b *BlockContext) Number() *big.Int {
 
 func (b *BlockContext) Payload() []byte {
 	return b.RawData
+}
+
+func (b *BlockContext) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, []interface{}{b.Height,b.RawData})
+}
+
+func (b *BlockContext) DecodeRLP(s *rlp.Stream) error {
+	var proposal struct {
+		RawData []byte
+		Height *big.Int
+	}
+
+	if err := s.Decode(&proposal); err != nil {
+		return err
+	}
+	b.RawData, b.Height = b.RawData, proposal.Height
+	return nil
 }
 
 type Request struct {


### PR DESCRIPTION
1. Replace gob with rlp. 
(Means that you do not have to implement ToPayload() using RequestContexter interface)
2. The data type of Msg has changed in Message struct. (inteface{} -> []byte, reason by 4)
3. A nil data is not supported by rlp encode.
4. A strong data type is needed for rlp decode.
```
type Proposal struct {
	Header         *ProposalHeader
	RequestContext RequestContexter
	Signatures     [][]byte
}

func (b *Proposal) DecodeRLP(s *rlp.Stream) error {
	var proposal struct {
		Header       *ProposalHeader
		**BlockContext *types.Block**
		Signatures   [][]byte
	}

	if err := s.Decode(&proposal); err != nil {
		return err
	}
	b.Header, b.RequestContext, b.Signatures = proposal.Header, proposal.BlockContext, proposal.Signatures
	return nil
}
```