### PR TITLE
core/types:  filter out useless information in Header.Extra under Istanbul consensus

### DIFF
--- a/consensus/istanbul/backends/simple/engine.go
+++ b/consensus/istanbul/backends/simple/engine.go
@@ -430,7 +430,7 @@ func (sb *simpleBackend) initValidatorSet(chain consensus.ChainReader) error {
 func (sb *simpleBackend) validExtraFormat(header *types.Header) bool {
 	length := len(header.Extra)
 	// ensure the bytes is enough
-	if length < types.ExtraVanity+types.ExtraValidatorSize+types.ExtraSeal {
+	if length < types.IstanbulExtraVanity +types.IstanbulExtraValidatorSize +types.IstanbulExtraSeal {
 		return false
 	}
 
@@ -439,7 +439,7 @@ func (sb *simpleBackend) validExtraFormat(header *types.Header) bool {
 	if vl == 0 {
 		return false
 	}
-	if length != types.ExtraVanity+types.ExtraValidatorSize+vl+types.ExtraSeal {
+	if length != types.IstanbulExtraVanity +types.IstanbulExtraValidatorSize +vl+types.IstanbulExtraSeal {
 		return false
 	}
 
@@ -447,7 +447,7 @@ func (sb *simpleBackend) validExtraFormat(header *types.Header) bool {
 }
 
 func (sb *simpleBackend) getValidatorBytes(header *types.Header) []byte {
-	return header.Extra[types.ExtraVanity+types.ExtraValidatorSize : types.ExtraVanity+types.ExtraValidatorSize+sb.validatorLength(header)]
+	return header.Extra[types.IstanbulExtraVanity +types.IstanbulExtraValidatorSize : types.IstanbulExtraVanity +types.IstanbulExtraValidatorSize +sb.validatorLength(header)]
 }
 
 // prepareExtra creates a copy that includes vanity, validators, and a clean seal for the given header
@@ -455,26 +455,26 @@ func (sb *simpleBackend) getValidatorBytes(header *types.Header) []byte {
 // note that the header.Extra consisted of vanity, validator size, validators, seal, and committed signatures
 func (sb *simpleBackend) prepareExtra(header, parent *types.Header) []byte {
 	buf := make([]byte, 0)
-	if len(header.Extra) < types.ExtraVanity {
-		header.Extra = append(header.Extra, bytes.Repeat([]byte{0x00}, types.ExtraVanity-len(header.Extra))...)
+	if len(header.Extra) < types.IstanbulExtraVanity {
+		header.Extra = append(header.Extra, bytes.Repeat([]byte{0x00}, types.IstanbulExtraVanity -len(header.Extra))...)
 	}
-	buf = header.Extra[:types.ExtraVanity]
+	buf = header.Extra[:types.IstanbulExtraVanity]
 
-	buf = append(buf, parent.Extra[types.ExtraVanity:types.ExtraVanity+types.ExtraValidatorSize+sb.validatorLength(parent)]...)
-	buf = append(buf, make([]byte, types.ExtraSeal)...)
+	buf = append(buf, parent.Extra[types.IstanbulExtraVanity:types.IstanbulExtraVanity +types.IstanbulExtraValidatorSize +sb.validatorLength(parent)]...)
+	buf = append(buf, make([]byte, types.IstanbulExtraSeal)...)
 	return buf
 }
 
 // signaturePosition returns start and end position for the given header
 func (sb *simpleBackend) signaturePosition(header *types.Header) (int, int) {
-	start := types.ExtraVanity + types.ExtraValidatorSize + sb.validatorLength(header)
-	end := start + types.ExtraSeal
+	start := types.IstanbulExtraVanity + types.IstanbulExtraValidatorSize + sb.validatorLength(header)
+	end := start + types.IstanbulExtraSeal
 	return int(start), int(end)
 }
 
 // validatorLength returns the validator length for the given header
 func (sb *simpleBackend) validatorLength(header *types.Header) int {
-	validatorSize := int(header.Extra[types.ExtraVanity : types.ExtraVanity+types.ExtraValidatorSize][0])
+	validatorSize := int(header.Extra[types.IstanbulExtraVanity : types.IstanbulExtraVanity +types.IstanbulExtraValidatorSize][0])
 	validatorLength := validatorSize * common.AddressLength
 	return int(validatorLength)
 }
@@ -503,7 +503,7 @@ func sigHash(header *types.Header) (hash common.Hash) {
 		header.GasLimit,
 		header.GasUsed,
 		header.Time,
-		header.Extra[:len(header.Extra)-types.ExtraSeal], // Yes, this will panic if extra is too short
+		header.Extra[:len(header.Extra)-types.IstanbulExtraSeal], // Yes, this will panic if extra is too short
 		header.MixDigest,
 		header.Nonce,
 	})
@@ -514,7 +514,7 @@ func sigHash(header *types.Header) (hash common.Hash) {
 // ecrecover extracts the Ethereum account address from a signed header.
 func (sb *simpleBackend) ecrecover(header *types.Header) (common.Address, error) {
 	// Retrieve the signature from the header extra-data
-	if len(header.Extra) < types.ExtraSeal {
+	if len(header.Extra) < types.IstanbulExtraSeal {
 		return common.Address{}, consensus.ErrMissingSignature
 	}
 	start, end := sb.signaturePosition(header)

--- a/consensus/istanbul/backends/simple/engine.go
+++ b/consensus/istanbul/backends/simple/engine.go
@@ -36,12 +36,6 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-const (
-	extraVanity        = 32 // Fixed number of extra-data prefix bytes reserved for signer vanity
-	extraValidatorSize = 1  // Fixed number of extra-data infix bytes reserved for validator size
-	extraSeal          = 65 // Fixed number of extra-data suffix bytes reserved for signer seal
-)
-
 var (
 	// errInvalidProposal is returned when a prposal is malformed.
 	errInvalidProposal = errors.New("invalid proposal")
@@ -436,7 +430,7 @@ func (sb *simpleBackend) initValidatorSet(chain consensus.ChainReader) error {
 func (sb *simpleBackend) validExtraFormat(header *types.Header) bool {
 	length := len(header.Extra)
 	// ensure the bytes is enough
-	if length < extraVanity+extraValidatorSize+extraSeal {
+	if length < types.ExtraVanity+types.ExtraValidatorSize+types.ExtraSeal {
 		return false
 	}
 
@@ -445,7 +439,7 @@ func (sb *simpleBackend) validExtraFormat(header *types.Header) bool {
 	if vl == 0 {
 		return false
 	}
-	if length != extraVanity+extraValidatorSize+vl+extraSeal {
+	if length != types.ExtraVanity+types.ExtraValidatorSize+vl+types.ExtraSeal {
 		return false
 	}
 
@@ -453,7 +447,7 @@ func (sb *simpleBackend) validExtraFormat(header *types.Header) bool {
 }
 
 func (sb *simpleBackend) getValidatorBytes(header *types.Header) []byte {
-	return header.Extra[extraVanity+extraValidatorSize : extraVanity+extraValidatorSize+sb.validatorLength(header)]
+	return header.Extra[types.ExtraVanity+types.ExtraValidatorSize : types.ExtraVanity+types.ExtraValidatorSize+sb.validatorLength(header)]
 }
 
 // prepareExtra creates a copy that includes vanity, validators, and a clean seal for the given header
@@ -461,26 +455,26 @@ func (sb *simpleBackend) getValidatorBytes(header *types.Header) []byte {
 // note that the header.Extra consisted of vanity, validator size, validators, seal, and committed signatures
 func (sb *simpleBackend) prepareExtra(header, parent *types.Header) []byte {
 	buf := make([]byte, 0)
-	if len(header.Extra) < extraVanity {
-		header.Extra = append(header.Extra, bytes.Repeat([]byte{0x00}, extraVanity-len(header.Extra))...)
+	if len(header.Extra) < types.ExtraVanity {
+		header.Extra = append(header.Extra, bytes.Repeat([]byte{0x00}, types.ExtraVanity-len(header.Extra))...)
 	}
-	buf = header.Extra[:extraVanity]
+	buf = header.Extra[:types.ExtraVanity]
 
-	buf = append(buf, parent.Extra[extraVanity:extraVanity+extraValidatorSize+sb.validatorLength(parent)]...)
-	buf = append(buf, make([]byte, extraSeal)...)
+	buf = append(buf, parent.Extra[types.ExtraVanity:types.ExtraVanity+types.ExtraValidatorSize+sb.validatorLength(parent)]...)
+	buf = append(buf, make([]byte, types.ExtraSeal)...)
 	return buf
 }
 
 // signaturePosition returns start and end position for the given header
 func (sb *simpleBackend) signaturePosition(header *types.Header) (int, int) {
-	start := extraVanity + extraValidatorSize + sb.validatorLength(header)
-	end := start + extraSeal
+	start := types.ExtraVanity + types.ExtraValidatorSize + sb.validatorLength(header)
+	end := start + types.ExtraSeal
 	return int(start), int(end)
 }
 
 // validatorLength returns the validator length for the given header
 func (sb *simpleBackend) validatorLength(header *types.Header) int {
-	validatorSize := int(header.Extra[extraVanity : extraVanity+extraValidatorSize][0])
+	validatorSize := int(header.Extra[types.ExtraVanity : types.ExtraVanity+types.ExtraValidatorSize][0])
 	validatorLength := validatorSize * common.AddressLength
 	return int(validatorLength)
 }
@@ -509,7 +503,7 @@ func sigHash(header *types.Header) (hash common.Hash) {
 		header.GasLimit,
 		header.GasUsed,
 		header.Time,
-		header.Extra[:len(header.Extra)-extraSeal], // Yes, this will panic if extra is too short
+		header.Extra[:len(header.Extra)-types.ExtraSeal], // Yes, this will panic if extra is too short
 		header.MixDigest,
 		header.Nonce,
 	})
@@ -520,7 +514,7 @@ func sigHash(header *types.Header) (hash common.Hash) {
 // ecrecover extracts the Ethereum account address from a signed header.
 func (sb *simpleBackend) ecrecover(header *types.Header) (common.Address, error) {
 	// Retrieve the signature from the header extra-data
-	if len(header.Extra) < extraSeal {
+	if len(header.Extra) < types.ExtraSeal {
 		return common.Address{}, consensus.ErrMissingSignature
 	}
 	start, end := sb.signaturePosition(header)

--- a/consensus/istanbul/backends/simple/engine_test.go
+++ b/consensus/istanbul/backends/simple/engine_test.go
@@ -77,10 +77,10 @@ func getGenesisAndKeys(n int) (*core.Genesis, []*ecdsa.PrivateKey) {
 }
 
 func appendValidators(genesis *core.Genesis, addrs []common.Address) {
-	if len(genesis.ExtraData) < extraVanity {
-		genesis.ExtraData = append(genesis.ExtraData, bytes.Repeat([]byte{0x00}, extraVanity)...)
+	if len(genesis.ExtraData) < types.ExtraVanity {
+		genesis.ExtraData = append(genesis.ExtraData, bytes.Repeat([]byte{0x00}, types.ExtraVanity)...)
 	}
-	genesis.ExtraData = genesis.ExtraData[:extraVanity]
+	genesis.ExtraData = genesis.ExtraData[:types.ExtraVanity]
 
 	validatorSize := byte(len(addrs))
 	genesis.ExtraData = append(genesis.ExtraData, validatorSize)
@@ -88,7 +88,7 @@ func appendValidators(genesis *core.Genesis, addrs []common.Address) {
 	for _, addr := range addrs {
 		genesis.ExtraData = append(genesis.ExtraData, addr[:]...)
 	}
-	genesis.ExtraData = append(genesis.ExtraData, make([]byte, extraSeal)...)
+	genesis.ExtraData = append(genesis.ExtraData, make([]byte, types.ExtraSeal)...)
 }
 
 func makeHeader(parent *types.Block, config *istanbul.Config) *types.Header {
@@ -435,10 +435,10 @@ OUT3:
 func TestPrepareExtra(t *testing.T) {
 	validatorN := 4
 	buf := make([]byte, 0)
-	buf = append(buf, make([]byte, extraVanity)...)
+	buf = append(buf, make([]byte, types.ExtraVanity)...)
 	buf = append(buf, byte(validatorN))
 	buf = append(buf, make([]byte, validatorN*common.AddressLength)...)
-	buf = append(buf, make([]byte, extraSeal)...)
+	buf = append(buf, make([]byte, types.ExtraSeal)...)
 
 	parentHeader := &types.Header{}
 	parentHeader.Extra = buf
@@ -447,7 +447,7 @@ func TestPrepareExtra(t *testing.T) {
 	header.Extra = common.StringToHash("123").Bytes()
 
 	expectedExtra := parentHeader.Extra
-	copy(expectedExtra[0:extraVanity], header.Extra)
+	copy(expectedExtra[0:types.ExtraVanity], header.Extra)
 
 	b, _, _ := newSimpleBackend()
 	extra := b.prepareExtra(header, parentHeader)
@@ -471,10 +471,10 @@ func TestSignaturePosition(t *testing.T) {
 	buf = append(buf, common.StringToHash("123").Bytes()...)
 	buf = append(buf, byte(validatorN))
 	buf = append(buf, make([]byte, validatorN*common.AddressLength)...)
-	buf = append(buf, make([]byte, extraSeal)...)
+	buf = append(buf, make([]byte, types.ExtraSeal)...)
 
-	expectedStart := extraVanity + extraValidatorSize + validatorN*common.AddressLength
-	expectedtEnd := expectedStart + extraSeal
+	expectedStart := types.ExtraVanity + types.ExtraValidatorSize + validatorN*common.AddressLength
+	expectedtEnd := expectedStart + types.ExtraSeal
 
 	header := &types.Header{}
 	header.Extra = buf
@@ -500,7 +500,7 @@ func TestValidExtra(t *testing.T) {
 				buf = append(buf, common.StringToHash("123").Bytes()...)
 				buf = append(buf, byte(validatorN))
 				buf = append(buf, make([]byte, validatorN*common.AddressLength)...)
-				buf = append(buf, make([]byte, extraSeal)...)
+				buf = append(buf, make([]byte, types.ExtraSeal)...)
 				return buf
 			}(),
 			true,
@@ -512,7 +512,7 @@ func TestValidExtra(t *testing.T) {
 				buf := make([]byte, 0)
 				buf = append(buf, common.StringToHash("123").Bytes()...)
 				buf = append(buf, byte(validatorN))
-				buf = append(buf, make([]byte, extraSeal)...)
+				buf = append(buf, make([]byte, types.ExtraSeal)...)
 				return buf
 			}(),
 			false,
@@ -525,7 +525,7 @@ func TestValidExtra(t *testing.T) {
 				buf = append(buf, common.StringToHash("123").Bytes()...)
 				buf = append(buf, byte(validatorN))
 				buf = append(buf, make([]byte, validatorN*common.AddressLength)...)
-				buf = append(buf, make([]byte, extraSeal)...)
+				buf = append(buf, make([]byte, types.ExtraSeal)...)
 				return buf
 			}(),
 			false,
@@ -538,7 +538,7 @@ func TestValidExtra(t *testing.T) {
 				buf = append(buf, common.StringToHash("123").Bytes()...)
 				buf = append(buf, byte(validatorN))
 				buf = append(buf, make([]byte, common.AddressLength)...)
-				buf = append(buf, make([]byte, extraSeal)...)
+				buf = append(buf, make([]byte, types.ExtraSeal)...)
 				return buf
 			}(),
 			false,

--- a/consensus/istanbul/backends/simple/engine_test.go
+++ b/consensus/istanbul/backends/simple/engine_test.go
@@ -77,10 +77,10 @@ func getGenesisAndKeys(n int) (*core.Genesis, []*ecdsa.PrivateKey) {
 }
 
 func appendValidators(genesis *core.Genesis, addrs []common.Address) {
-	if len(genesis.ExtraData) < types.ExtraVanity {
-		genesis.ExtraData = append(genesis.ExtraData, bytes.Repeat([]byte{0x00}, types.ExtraVanity)...)
+	if len(genesis.ExtraData) < types.IstanbulExtraVanity {
+		genesis.ExtraData = append(genesis.ExtraData, bytes.Repeat([]byte{0x00}, types.IstanbulExtraVanity)...)
 	}
-	genesis.ExtraData = genesis.ExtraData[:types.ExtraVanity]
+	genesis.ExtraData = genesis.ExtraData[:types.IstanbulExtraVanity]
 
 	validatorSize := byte(len(addrs))
 	genesis.ExtraData = append(genesis.ExtraData, validatorSize)
@@ -88,7 +88,7 @@ func appendValidators(genesis *core.Genesis, addrs []common.Address) {
 	for _, addr := range addrs {
 		genesis.ExtraData = append(genesis.ExtraData, addr[:]...)
 	}
-	genesis.ExtraData = append(genesis.ExtraData, make([]byte, types.ExtraSeal)...)
+	genesis.ExtraData = append(genesis.ExtraData, make([]byte, types.IstanbulExtraSeal)...)
 }
 
 func makeHeader(parent *types.Block, config *istanbul.Config) *types.Header {
@@ -435,10 +435,10 @@ OUT3:
 func TestPrepareExtra(t *testing.T) {
 	validatorN := 4
 	buf := make([]byte, 0)
-	buf = append(buf, make([]byte, types.ExtraVanity)...)
+	buf = append(buf, make([]byte, types.IstanbulExtraVanity)...)
 	buf = append(buf, byte(validatorN))
 	buf = append(buf, make([]byte, validatorN*common.AddressLength)...)
-	buf = append(buf, make([]byte, types.ExtraSeal)...)
+	buf = append(buf, make([]byte, types.IstanbulExtraSeal)...)
 
 	parentHeader := &types.Header{}
 	parentHeader.Extra = buf
@@ -447,7 +447,7 @@ func TestPrepareExtra(t *testing.T) {
 	header.Extra = common.StringToHash("123").Bytes()
 
 	expectedExtra := parentHeader.Extra
-	copy(expectedExtra[0:types.ExtraVanity], header.Extra)
+	copy(expectedExtra[0:types.IstanbulExtraVanity], header.Extra)
 
 	b, _, _ := newSimpleBackend()
 	extra := b.prepareExtra(header, parentHeader)
@@ -471,10 +471,10 @@ func TestSignaturePosition(t *testing.T) {
 	buf = append(buf, common.StringToHash("123").Bytes()...)
 	buf = append(buf, byte(validatorN))
 	buf = append(buf, make([]byte, validatorN*common.AddressLength)...)
-	buf = append(buf, make([]byte, types.ExtraSeal)...)
+	buf = append(buf, make([]byte, types.IstanbulExtraSeal)...)
 
-	expectedStart := types.ExtraVanity + types.ExtraValidatorSize + validatorN*common.AddressLength
-	expectedtEnd := expectedStart + types.ExtraSeal
+	expectedStart := types.IstanbulExtraVanity + types.IstanbulExtraValidatorSize + validatorN*common.AddressLength
+	expectedtEnd := expectedStart + types.IstanbulExtraSeal
 
 	header := &types.Header{}
 	header.Extra = buf
@@ -500,7 +500,7 @@ func TestValidExtra(t *testing.T) {
 				buf = append(buf, common.StringToHash("123").Bytes()...)
 				buf = append(buf, byte(validatorN))
 				buf = append(buf, make([]byte, validatorN*common.AddressLength)...)
-				buf = append(buf, make([]byte, types.ExtraSeal)...)
+				buf = append(buf, make([]byte, types.IstanbulExtraSeal)...)
 				return buf
 			}(),
 			true,
@@ -512,7 +512,7 @@ func TestValidExtra(t *testing.T) {
 				buf := make([]byte, 0)
 				buf = append(buf, common.StringToHash("123").Bytes()...)
 				buf = append(buf, byte(validatorN))
-				buf = append(buf, make([]byte, types.ExtraSeal)...)
+				buf = append(buf, make([]byte, types.IstanbulExtraSeal)...)
 				return buf
 			}(),
 			false,
@@ -525,7 +525,7 @@ func TestValidExtra(t *testing.T) {
 				buf = append(buf, common.StringToHash("123").Bytes()...)
 				buf = append(buf, byte(validatorN))
 				buf = append(buf, make([]byte, validatorN*common.AddressLength)...)
-				buf = append(buf, make([]byte, types.ExtraSeal)...)
+				buf = append(buf, make([]byte, types.IstanbulExtraSeal)...)
 				return buf
 			}(),
 			false,
@@ -538,7 +538,7 @@ func TestValidExtra(t *testing.T) {
 				buf = append(buf, common.StringToHash("123").Bytes()...)
 				buf = append(buf, byte(validatorN))
 				buf = append(buf, make([]byte, common.AddressLength)...)
-				buf = append(buf, make([]byte, types.ExtraSeal)...)
+				buf = append(buf, make([]byte, types.IstanbulExtraSeal)...)
 				return buf
 			}(),
 			false,

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -99,6 +99,9 @@ type headerMarshaling struct {
 // Hash returns the block hash of the header, which is simply the keccak256 hash of its
 // RLP encoding.
 func (h *Header) Hash() common.Hash {
+	if h.MixDigest == IstanbulDigest {
+		return rlpHash(IstanbulExtraFilter(h))
+	}
 	return rlpHash(h)
 }
 

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -384,7 +384,7 @@ func (b *Block) Hash() common.Hash {
 	if hash := b.hash.Load(); hash != nil {
 		return hash.(common.Hash)
 	}
-	v := rlpHash(b.header)
+	v := b.header.Hash()
 	b.hash.Store(v)
 	return v
 }

--- a/core/types/istanbul.go
+++ b/core/types/istanbul.go
@@ -1,0 +1,64 @@
+// Copyright 2017 AMIS Technologies
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var (
+	// The IstanbulDigest represents a constant of "Istanbul practical byzantine fault tolerance".
+	IstanbulDigest = common.HexToHash("0x63746963616c2062797a616e74696e65206661756c7420746f6c6572616e6365")
+
+	ExtraVanity        = int(params.MaximumExtraDataSize) // Fixed number of extra-data prefix bytes reserved for signer vanity
+	ExtraValidatorSize = 1                                // Fixed number of extra-data infix bytes reserved for validator size
+	ExtraSeal          = 65                               // Fixed number of extra-data suffix bytes reserved for signer seal
+)
+
+// IstanbulExtraFilter is used to filter out the useless information.
+//
+// We just keep the following data in header.Extra.
+// ┌─────────────────┬──────────────────────┬────────────────────────────────┬───────────────┐
+// │ vanity(32 bytes)│ validator#N (1 bytes)│ validator address(N * 20 bytes)│ seal(65 bytes)│
+// └─────────────────┴──────────────────────┴────────────────────────────────┴───────────────┘
+func IstanbulExtraFilter(h *Header) *Header {
+	newHeader := CopyHeader(h)
+	defaultLength := ExtraVanity + ExtraValidatorSize + ExtraSeal
+
+	// The number of validator addresses is not known since the extra may be insufficient,
+	// but we can checks whether extra is enough(vanity + validator#N + seal).
+	// If it is not enough, compensate the lack of bytes to avoid panic in getting slice.
+	if len(newHeader.Extra) < defaultLength {
+		newHeader.Extra = append(newHeader.Extra, bytes.Repeat([]byte{0x00}, defaultLength-len(newHeader.Extra))...)
+	}
+
+	// Calculate the validator length.
+	valLength := int(newHeader.Extra[ExtraVanity : ExtraVanity+ExtraValidatorSize][0]) * common.AddressLength
+
+	// Same as before, but validator length is also considered.
+	if len(newHeader.Extra) < defaultLength+valLength {
+		newHeader.Extra = append(newHeader.Extra, bytes.Repeat([]byte{0x00}, defaultLength+valLength-len(newHeader.Extra))...)
+	}
+
+	// We just keep vanity, validator#N, validators, and seal in Extra.
+	newHeader.Extra = newHeader.Extra[0 : ExtraVanity+ExtraValidatorSize+valLength+ExtraSeal]
+
+	return newHeader
+}

--- a/core/types/istanbul.go
+++ b/core/types/istanbul.go
@@ -27,9 +27,9 @@ var (
 	// The IstanbulDigest represents a constant of "Istanbul practical byzantine fault tolerance".
 	IstanbulDigest = common.HexToHash("0x63746963616c2062797a616e74696e65206661756c7420746f6c6572616e6365")
 
-	ExtraVanity        = int(params.MaximumExtraDataSize) // Fixed number of extra-data prefix bytes reserved for signer vanity
-	ExtraValidatorSize = 1                                // Fixed number of extra-data infix bytes reserved for validator size
-	ExtraSeal          = 65                               // Fixed number of extra-data suffix bytes reserved for signer seal
+	IstanbulExtraVanity        = int(params.MaximumExtraDataSize) // Fixed number of extra-data prefix bytes reserved for signer vanity
+	IstanbulExtraValidatorSize = 1                                // Fixed number of extra-data infix bytes reserved for validator size
+	IstanbulExtraSeal          = 65                               // Fixed number of extra-data suffix bytes reserved for signer seal
 )
 
 // IstanbulExtraFilter is used to filter out the useless information.
@@ -40,7 +40,7 @@ var (
 // └─────────────────┴──────────────────────┴────────────────────────────────┴───────────────┘
 func IstanbulExtraFilter(h *Header) *Header {
 	newHeader := CopyHeader(h)
-	defaultLength := ExtraVanity + ExtraValidatorSize + ExtraSeal
+	defaultLength := IstanbulExtraVanity + IstanbulExtraValidatorSize + IstanbulExtraSeal
 
 	// The number of validator addresses is not known since the extra may be insufficient,
 	// but we can checks whether extra is enough(vanity + validator#N + seal).
@@ -50,7 +50,7 @@ func IstanbulExtraFilter(h *Header) *Header {
 	}
 
 	// Calculate the validator length.
-	valLength := int(newHeader.Extra[ExtraVanity : ExtraVanity+ExtraValidatorSize][0]) * common.AddressLength
+	valLength := int(newHeader.Extra[IstanbulExtraVanity : IstanbulExtraVanity+IstanbulExtraValidatorSize][0]) * common.AddressLength
 
 	// Same as before, but validator length is also considered.
 	if len(newHeader.Extra) < defaultLength+valLength {
@@ -58,7 +58,7 @@ func IstanbulExtraFilter(h *Header) *Header {
 	}
 
 	// We just keep vanity, validator#N, validators, and seal in Extra.
-	newHeader.Extra = newHeader.Extra[0 : ExtraVanity+ExtraValidatorSize+valLength+ExtraSeal]
+	newHeader.Extra = newHeader.Extra[0 : IstanbulExtraVanity+IstanbulExtraValidatorSize+valLength+IstanbulExtraSeal]
 
 	return newHeader
 }

--- a/core/types/istanbul_test.go
+++ b/core/types/istanbul_test.go
@@ -54,10 +54,10 @@ func TestIstanbulExtraFilter(t *testing.T) {
 		{hexutil.MustDecode("0x00000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"), hexutil.MustDecode("0x00000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")},
 
 		// extra is nil
-		{[]byte{}, bytes.Repeat([]byte{0x00}, ExtraVanity+ExtraValidatorSize+ExtraSeal)},
+		{[]byte{}, bytes.Repeat([]byte{0x00}, IstanbulExtraVanity + IstanbulExtraValidatorSize + IstanbulExtraSeal)},
 
 		// information is not enough
-		{[]byte{1, 2, 3}, append([]byte{1, 2, 3}, bytes.Repeat([]byte{0x00}, ExtraVanity+ExtraValidatorSize+ExtraSeal-3 /*testExtra size is 3*/)...)},
+		{[]byte{1, 2, 3}, append([]byte{1, 2, 3}, bytes.Repeat([]byte{0x00}, IstanbulExtraVanity + IstanbulExtraValidatorSize + IstanbulExtraSeal -3 /*testExtra size is 3*/)...)},
 
 		// validator size not mapping to validator length
 		// validator size is 1, but validator length is 0

--- a/core/types/istanbul_test.go
+++ b/core/types/istanbul_test.go
@@ -1,0 +1,77 @@
+// Copyright 2017 AMIS Technologies
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+func TestHeaderHash(t *testing.T) {
+	// 0xac1777d3630c38a34f60ab6bd4ff14160ab3781afa3a0bf565619b036265a02e
+	expectedExtra := common.FromHex("0x00000000000000000000000000000000000000000000000000000000000000000444add0ec310f115a0e603b2d7db9f067778eaf8a294fc7e8f22b3bcdcf955dd7ff3ba2ed833f82126beaaed781d2d2ab6350f5c4566a2c6eaac407a68be76812f765c24641ec63dc2852b378aba2b4400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
+	expectedHash := common.HexToHash("0xac1777d3630c38a34f60ab6bd4ff14160ab3781afa3a0bf565619b036265a02e")
+
+	// for istanbul consensus
+	header := &Header{MixDigest: IstanbulDigest, Extra: expectedExtra}
+	if !reflect.DeepEqual(header.Hash(), expectedHash) {
+		t.Errorf("expected: %v, but got: %v", expectedHash, header.Hash())
+	}
+
+	// useless information
+	unexpectedExtra := append(expectedExtra, []byte{1, 2, 3}...)
+	header.Extra = unexpectedExtra
+	if !reflect.DeepEqual(header.Hash(), expectedHash) {
+		t.Errorf("expected: %v, but got: %v", expectedHash, header.Hash())
+	}
+}
+
+func TestIstanbulExtraFilter(t *testing.T) {
+	testCases := []struct {
+		testExtra []byte
+
+		expectedExtra []byte
+	}{
+		// valid extra
+		{hexutil.MustDecode("0x00000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"), hexutil.MustDecode("0x00000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")},
+
+		// extra is nil
+		{[]byte{}, bytes.Repeat([]byte{0x00}, ExtraVanity+ExtraValidatorSize+ExtraSeal)},
+
+		// information is not enough
+		{[]byte{1, 2, 3}, append([]byte{1, 2, 3}, bytes.Repeat([]byte{0x00}, ExtraVanity+ExtraValidatorSize+ExtraSeal-3 /*testExtra size is 3*/)...)},
+
+		// validator size not mapping to validator length
+		// validator size is 1, but validator length is 0
+		{hexutil.MustDecode("0x0000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"), hexutil.MustDecode("0x00000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")},
+
+		// wrong signature length, 60 bytes
+		{hexutil.MustDecode("0x000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"), hexutil.MustDecode("0x00000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")},
+	}
+
+	for _, test := range testCases {
+		newHeader := IstanbulExtraFilter(&Header{Extra: test.testExtra})
+
+		if !reflect.DeepEqual(newHeader.Extra, test.expectedExtra) {
+			t.Errorf("expected: %v, but got: %v", test.expectedExtra, newHeader.Extra)
+		}
+	}
+}


### PR DESCRIPTION
We just keep vanity(32 bytes), validator#N(1 byte), validator length(N*20bytes), seal(65 bytes) in header.Extra 
