### PR TITLE
eth, consensus/istanbul: support Istanbul config in TOML config

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -469,7 +469,7 @@ var (
 	IstanbulRequestTimeoutFlag = cli.Uint64Flag{
 		Name:  "istanbul.requesttimeout",
 		Usage: "Timeout for each Istanbul round in milliseconds",
-		Value: eth.DefaultConfig.Istanbul.RequestTimeoutMsec,
+		Value: eth.DefaultConfig.Istanbul.RequestTimeout,
 	}
 	IstanbulBlockPeriodFlag = cli.Uint64Flag{
 		Name:  "istanbul.blockperiod",
@@ -896,7 +896,7 @@ func setEthash(ctx *cli.Context, cfg *eth.Config) {
 
 func setIstanbul(ctx *cli.Context, cfg *eth.Config) {
 	if ctx.GlobalIsSet(IstanbulRequestTimeoutFlag.Name) {
-		cfg.Istanbul.RequestTimeoutMsec = ctx.GlobalUint64(IstanbulRequestTimeoutFlag.Name)
+		cfg.Istanbul.RequestTimeout = ctx.GlobalUint64(IstanbulRequestTimeoutFlag.Name)
 	}
 	if ctx.GlobalIsSet(IstanbulBlockPeriodFlag.Name) {
 		cfg.Istanbul.BlockPeriod = ctx.GlobalUint64(IstanbulBlockPeriodFlag.Name)

--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -23,17 +23,17 @@ const (
 )
 
 type Config struct {
-	RequestTimeoutMsec uint64         `toml:"RequestTimeout,omitempty"` // The timeout for each Istanbul round. This timeout should be larger than BlockPauseTime.
-	BlockPeriod        uint64         `toml:",omitempty"`               // Default minimum difference between two consecutive block's timestamps in second
-	BlockPauseTime     uint64         `toml:",omitempty"`               // Pause time when zero tx in previous block, values should be larger than istanbul_block_period
-	ProposerPolicy     ProposerPolicy `toml:",omitempty"`               // The policy for proposer, the detail is not determined
-	CheckPointPeriod   int            `toml:",omitempty"`               // Synchronizes the mapping's checkpoint to the blocks on each round
+	RequestTimeout   uint64         `toml:",omitempty"` // The timeout for each Istanbul round in milliseconds. This timeout should be larger than BlockPauseTime.
+	BlockPeriod      uint64         `toml:",omitempty"` // Default minimum difference between two consecutive block's timestamps in second
+	BlockPauseTime   uint64         `toml:",omitempty"` // Pause time when zero tx in previous block, values should be larger than istanbul_block_period
+	ProposerPolicy   ProposerPolicy `toml:",omitempty"` // The policy for proposer, the detail is not determined
+	CheckPointPeriod int            `toml:",omitempty"` // Synchronizes the mapping's checkpoint to the blocks on each round
 }
 
 var DefaultConfig = &Config{
-	RequestTimeoutMsec: 10000,
-	BlockPeriod:        1,
-	BlockPauseTime:     2,
-	ProposerPolicy:     RoundRobin,
-	CheckPointPeriod:   100,
+	RequestTimeout:   10000,
+	BlockPeriod:      1,
+	BlockPauseTime:   2,
+	ProposerPolicy:   RoundRobin,
+	CheckPointPeriod: 100,
 }

--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -23,11 +23,11 @@ const (
 )
 
 type Config struct {
-	RequestTimeoutMsec uint64         // The timeout for each Istanbul round. This timeout should be larger than BlockPauseTime.
-	BlockPeriod        uint64         // Default minimum difference between two consecutive block's timestamps in second
-	BlockPauseTime     uint64         // Pause time when zero tx in previous block, values should be larger than istanbul_block_period
-	ProposerPolicy     ProposerPolicy // The policy for proposer, the detail is not determined
-	CheckPointPeriod   int            // Synchronizes the mapping's checkpoint to the blocks on each round
+	RequestTimeoutMsec uint64         `toml:"RequestTimeout,omitempty"` // The timeout for each Istanbul round. This timeout should be larger than BlockPauseTime.
+	BlockPeriod        uint64         `toml:",omitempty"`               // Default minimum difference between two consecutive block's timestamps in second
+	BlockPauseTime     uint64         `toml:",omitempty"`               // Pause time when zero tx in previous block, values should be larger than istanbul_block_period
+	ProposerPolicy     ProposerPolicy `toml:",omitempty"`               // The policy for proposer, the detail is not determined
+	CheckPointPeriod   int            `toml:",omitempty"`               // Synchronizes the mapping's checkpoint to the blocks on each round
 }
 
 var DefaultConfig = &Config{

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -246,7 +246,7 @@ func (c *core) newRoundChangeTimer() {
 		c.roundChangeTimer.Stop()
 	}
 
-	timeout := time.Duration(c.config.RequestTimeoutMsec) * time.Millisecond
+	timeout := time.Duration(c.config.RequestTimeout) * time.Millisecond
 	c.roundChangeTimer = time.AfterFunc(timeout, func() {
 		c.sendRoundChange()
 	})

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -221,7 +221,7 @@ func CreateConsensusEngine(ctx *node.ServiceContext, config *Config, chainConfig
 	}
 	// If Istanbul is requested, set it up
 	if chainConfig.Istanbul != nil {
-		return istanbul.New(config.Istanbul, ctx.EventMux, ctx.NodeKey(), db)
+		return istanbul.New(&config.Istanbul, ctx.EventMux, ctx.NodeKey(), db)
 	}
 
 	// Otherwise assume proof-of-work

--- a/eth/config.go
+++ b/eth/config.go
@@ -51,7 +51,7 @@ var DefaultConfig = Config{
 		Percentile: 50,
 	},
 
-	Istanbul: istanbul.DefaultConfig,
+	Istanbul: *istanbul.DefaultConfig,
 }
 
 func init() {
@@ -113,7 +113,7 @@ type Config struct {
 	EnablePreimageRecording bool
 
 	// Istanbul options
-	Istanbul *istanbul.Config
+	Istanbul istanbul.Config
 
 	// Miscellaneous options
 	DocRoot   string `toml:"-"`

--- a/eth/gen_config.go
+++ b/eth/gen_config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/gasprice"
@@ -36,6 +37,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		TxPool                  core.TxPoolConfig
 		GPO                     gasprice.Config
 		EnablePreimageRecording bool
+		Istanbul                istanbul.Config
 		DocRoot                 string `toml:"-"`
 		PowFake                 bool   `toml:"-"`
 		PowTest                 bool   `toml:"-"`
@@ -64,6 +66,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.TxPool = c.TxPool
 	enc.GPO = c.GPO
 	enc.EnablePreimageRecording = c.EnablePreimageRecording
+	enc.Istanbul = c.Istanbul
 	enc.DocRoot = c.DocRoot
 	enc.PowFake = c.PowFake
 	enc.PowTest = c.PowTest
@@ -95,6 +98,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		TxPool                  *core.TxPoolConfig
 		GPO                     *gasprice.Config
 		EnablePreimageRecording *bool
+		Istanbul                *istanbul.Config
 		DocRoot                 *string `toml:"-"`
 		PowFake                 *bool   `toml:"-"`
 		PowTest                 *bool   `toml:"-"`
@@ -169,6 +173,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.EnablePreimageRecording != nil {
 		c.EnablePreimageRecording = *dec.EnablePreimageRecording
+	}
+	if dec.Istanbul != nil {
+		c.Istanbul = *dec.Istanbul
 	}
 	if dec.DocRoot != nil {
 		c.DocRoot = *dec.DocRoot


### PR DESCRIPTION
You could try it with a example configuration file.
```toml
[Node]
HTTPHost = "127.0.0.1"
HTTPPort = 8080
HTTPCors = ["*"]
HTTPModules = ["net", "web3", "eth", "db"]
DataDir = "tmpdata"

[Node.P2P]
ListenAddr = ":30303"
MaxPeers = 100

[Eth]
MinerThreads = 1
NetworkId = 20160816
SyncMode = "fast"

[Eth.Istanbul]
RequestTimeout = 10000
BlockPeriod = 1
BlockPauseTime = 2
ProposerPolicy = 0
CheckPointPeriod = 100
```