### PR TITLE
consensus/*, eth, ethstats, miner: add block lock and some features

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -106,15 +106,15 @@ type PoW interface {
 type Istanbul interface {
 	Engine
 
-	// Handle a message from peer
+	// HandleMsg handles a message from peer
 	HandleMsg(pubKey *ecdsa.PublicKey, data []byte) error
 
-	// Receive new chain head block
-	NewChainHead(block *types.Block)
+	// NewChainHead is called if a new chain head block comes
+	NewChainHead(block *types.Block) error
 
-	// Start the engine
-	Start(chain ChainReader, inserter func(block *types.Block) error) error
+	// Start starts the engine
+	Start(chain ChainReader, inserter func(types.Blocks) (int, error)) error
 
-	// Stop the engine
+	// Stop stops the engine
 	Stop() error
 }

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -26,7 +26,7 @@ import (
 // API is a user facing RPC API to dump Istanbul state
 type API struct {
 	chain    consensus.ChainReader
-	istanbul *simpleBackend
+	istanbul *backend
 }
 
 // GetSnapshot retrieves the state snapshot at a given block.

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -18,19 +18,21 @@ package backend
 
 import (
 	"crypto/ecdsa"
+	"math/big"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	istanbulCore "github.com/ethereum/go-ethereum/consensus/istanbul/core"
 	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/miner"
 	lru "github.com/hashicorp/golang-lru"
 )
 
@@ -38,24 +40,26 @@ import (
 func New(config *istanbul.Config, eventMux *event.TypeMux, privateKey *ecdsa.PrivateKey, db ethdb.Database) consensus.Istanbul {
 	// Allocate the snapshot caches and create the engine
 	recents, _ := lru.NewARC(inmemorySnapshots)
-	backend := &simpleBackend{
+	backend := &backend{
 		config:           config,
 		eventMux:         eventMux,
 		istanbulEventMux: new(event.TypeMux),
 		privateKey:       privateKey,
 		address:          crypto.PubkeyToAddress(privateKey.PublicKey),
-		logger:           log.New("backend", "simple"),
+		logger:           log.New(),
 		db:               db,
 		commitCh:         make(chan *types.Block, 1),
 		recents:          recents,
 		candidates:       make(map[common.Address]bool),
+		coreStarted:      false,
 	}
+	backend.core = istanbulCore.New(backend, backend.config)
 	return backend
 }
 
 // ----------------------------------------------------------------------------
 
-type simpleBackend struct {
+type backend struct {
 	config           *istanbul.Config
 	eventMux         *event.TypeMux
 	istanbulEventMux *event.TypeMux
@@ -63,16 +67,16 @@ type simpleBackend struct {
 	address          common.Address
 	core             istanbulCore.Engine
 	logger           log.Logger
-	quitSync         chan struct{}
 	db               ethdb.Database
-	timeout          uint64
 	chain            consensus.ChainReader
-	inserter         func(block *types.Block) error
+	inserter         func(types.Blocks) (int, error)
 
 	// the channels for istanbul engine notifications
 	commitCh          chan *types.Block
 	proposedBlockHash common.Hash
 	sealMu            sync.Mutex
+	coreStarted       bool
+	coreMu            sync.Mutex
 
 	// Current list of candidates we are pushing
 	candidates map[common.Address]bool
@@ -83,29 +87,18 @@ type simpleBackend struct {
 }
 
 // Address implements istanbul.Backend.Address
-func (sb *simpleBackend) Address() common.Address {
+func (sb *backend) Address() common.Address {
 	return sb.address
 }
 
 // Validators implements istanbul.Backend.Validators
-func (sb *simpleBackend) Validators(proposal istanbul.Proposal) istanbul.ValidatorSet {
-	snap, err := sb.snapshot(sb.chain, proposal.Number().Uint64(), proposal.Hash(), nil)
-	if err != nil {
-		return validator.NewSet(nil, sb.config.ProposerPolicy)
-	}
-	return snap.ValSet
-}
-
-func (sb *simpleBackend) Send(payload []byte, target common.Address) error {
-	go sb.eventMux.Post(istanbul.ConsensusDataEvent{
-		Target: target,
-		Data:   payload,
-	})
-	return nil
+func (sb *backend) Validators(proposal istanbul.Proposal) istanbul.ValidatorSet {
+	return sb.getValidators(proposal.Number().Uint64(), proposal.Hash())
 }
 
 // Broadcast implements istanbul.Backend.Send
-func (sb *simpleBackend) Broadcast(valSet istanbul.ValidatorSet, payload []byte) error {
+func (sb *backend) Broadcast(valSet istanbul.ValidatorSet, payload []byte) error {
+	targets := make(map[common.Address]bool)
 	for _, val := range valSet.List() {
 		if val.Address() == sb.Address() {
 			// send to self
@@ -116,14 +109,21 @@ func (sb *simpleBackend) Broadcast(valSet istanbul.ValidatorSet, payload []byte)
 
 		} else {
 			// send to other peers
-			sb.Send(payload, val.Address())
+			targets[val.Address()] = true
 		}
+	}
+
+	if len(targets) > 0 {
+		go sb.eventMux.Post(istanbul.ConsensusDataEvent{
+			Targets: targets,
+			Data:    payload,
+		})
 	}
 	return nil
 }
 
 // Commit implements istanbul.Backend.Commit
-func (sb *simpleBackend) Commit(proposal istanbul.Proposal, seals []byte) error {
+func (sb *backend) Commit(proposal istanbul.Proposal, seals [][]byte) error {
 	// Check if the proposal is a valid block
 	block := &types.Block{}
 	block, ok := proposal.(*types.Block)
@@ -154,49 +154,58 @@ func (sb *simpleBackend) Commit(proposal istanbul.Proposal, seals []byte) error 
 		// TODO: how do we check the block is inserted correctly?
 		return nil
 	}
-
-	return sb.inserter(block)
+	// if I'm not a proposer, insert the block directly and broadcast NewCommittedEvent
+	if _, err := sb.inserter(types.Blocks{block}); err != nil {
+		return err
+	}
+	msg := istanbul.NewCommittedEvent{
+		Block: block,
+	}
+	go sb.eventMux.Post(msg)
+	return nil
 }
 
-// NextRound will broadcast ChainHeadEvent to trigger next seal()
-func (sb *simpleBackend) NextRound() error {
+// NextRound will broadcast NewBlockEvent to trigger next seal()
+func (sb *backend) NextRound() error {
 	header := sb.chain.CurrentHeader()
 	sb.logger.Debug("NextRound", "address", sb.Address(), "current_hash", header.Hash(), "current_number", header.Number)
-	go sb.eventMux.Post(core.ChainHeadEvent{})
+	go sb.eventMux.Post(miner.NewBlockEvent{})
 	return nil
 }
 
 // EventMux implements istanbul.Backend.EventMux
-func (sb *simpleBackend) EventMux() *event.TypeMux {
+func (sb *backend) EventMux() *event.TypeMux {
 	return sb.istanbulEventMux
 }
 
 // Verify implements istanbul.Backend.Verify
-func (sb *simpleBackend) Verify(proposal istanbul.Proposal) error {
+func (sb *backend) Verify(proposal istanbul.Proposal) (time.Duration, error) {
 	// Check if the proposal is a valid block
 	block := &types.Block{}
 	block, ok := proposal.(*types.Block)
 	if !ok {
 		sb.logger.Error("Invalid proposal, %v", proposal)
-		return errInvalidProposal
+		return 0, errInvalidProposal
 	}
 	// verify the header of proposed block
 	err := sb.VerifyHeader(sb.chain, block.Header(), false)
-	// Ignore errEmptyCommittedSeals error because we don't have the committed seals yet
-	if err != nil && err != errEmptyCommittedSeals {
-		return err
+	// ignore errEmptyCommittedSeals error because we don't have the committed seals yet
+	if err == nil || err == errEmptyCommittedSeals {
+		return 0, nil
+	} else if err == consensus.ErrFutureBlock {
+		return time.Unix(block.Header().Time.Int64(), 0).Sub(now()), consensus.ErrFutureBlock
 	}
-	return nil
+	return 0, err
 }
 
 // Sign implements istanbul.Backend.Sign
-func (sb *simpleBackend) Sign(data []byte) ([]byte, error) {
+func (sb *backend) Sign(data []byte) ([]byte, error) {
 	hashData := crypto.Keccak256([]byte(data))
 	return crypto.Sign(hashData, sb.privateKey)
 }
 
 // CheckSignature implements istanbul.Backend.CheckSignature
-func (sb *simpleBackend) CheckSignature(data []byte, address common.Address, sig []byte) error {
+func (sb *backend) CheckSignature(data []byte, address common.Address, sig []byte) error {
 	signer, err := istanbul.GetSignatureAddress(data, sig)
 	if err != nil {
 		log.Error("Failed to get signer address", "err", err)
@@ -207,4 +216,34 @@ func (sb *simpleBackend) CheckSignature(data []byte, address common.Address, sig
 		return errInvalidSignature
 	}
 	return nil
+}
+
+// HasBlock implements istanbul.Backend.HashBlock
+func (sb *backend) HasBlock(hash common.Hash, number *big.Int) bool {
+	return sb.chain.GetHeader(hash, number.Uint64()) != nil
+}
+
+// GetProposer implements istanbul.Backend.GetProposer
+func (sb *backend) GetProposer(number uint64) common.Address {
+	if h := sb.chain.GetHeaderByNumber(number); h != nil {
+		a, _ := sb.Author(h)
+		return a
+	}
+	return common.Address{}
+}
+
+// ParentValidators implements istanbul.Backend.GetParentValidators
+func (sb *backend) ParentValidators(proposal istanbul.Proposal) istanbul.ValidatorSet {
+	if block, ok := proposal.(*types.Block); ok {
+		return sb.getValidators(block.Number().Uint64()-1, block.ParentHash())
+	}
+	return validator.NewSet(nil, sb.config.ProposerPolicy)
+}
+
+func (sb *backend) getValidators(number uint64, hash common.Hash) istanbul.ValidatorSet {
+	snap, err := sb.snapshot(sb.chain, number, hash, nil)
+	if err != nil {
+		return validator.NewSet(nil, sb.config.ProposerPolicy)
+	}
+	return snap.ValSet
 }

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
+	lru "github.com/hashicorp/golang-lru"
 )
 
 const (
@@ -88,19 +89,22 @@ var (
 
 	nonceAuthVote = hexutil.MustDecode("0xffffffffffffffff") // Magic nonce number to vote on adding a new validator
 	nonceDropVote = hexutil.MustDecode("0x0000000000000000") // Magic nonce number to vote on removing a validator.
+
+	inmemoryAddresses  = 20 // Number of recent addresses from ecrecover
+	recentAddresses, _ = lru.NewARC(inmemoryAddresses)
 )
 
 // Author retrieves the Ethereum address of the account that minted the given
 // block, which may be different from the header's coinbase if a consensus
 // engine is based on signatures.
-func (sb *simpleBackend) Author(header *types.Header) (common.Address, error) {
+func (sb *backend) Author(header *types.Header) (common.Address, error) {
 	return ecrecover(header)
 }
 
 // VerifyHeader checks whether a header conforms to the consensus rules of a
 // given engine. Verifying the seal may be done optionally here, or explicitly
 // via the VerifySeal method.
-func (sb *simpleBackend) VerifyHeader(chain consensus.ChainReader, header *types.Header, seal bool) error {
+func (sb *backend) VerifyHeader(chain consensus.ChainReader, header *types.Header, seal bool) error {
 	return sb.verifyHeader(chain, header, nil)
 }
 
@@ -108,7 +112,7 @@ func (sb *simpleBackend) VerifyHeader(chain consensus.ChainReader, header *types
 // caller may optionally pass in a batch of parents (ascending order) to avoid
 // looking those up from the database. This is useful for concurrently verifying
 // a batch of new headers.
-func (sb *simpleBackend) verifyHeader(chain consensus.ChainReader, header *types.Header, parents []*types.Header) error {
+func (sb *backend) verifyHeader(chain consensus.ChainReader, header *types.Header, parents []*types.Header) error {
 	if header.Number == nil {
 		return errUnknownBlock
 	}
@@ -147,7 +151,7 @@ func (sb *simpleBackend) verifyHeader(chain consensus.ChainReader, header *types
 // rather depend on a batch of previous headers. The caller may optionally pass
 // in a batch of parents (ascending order) to avoid looking those up from the
 // database. This is useful for concurrently verifying a batch of new headers.
-func (sb *simpleBackend) verifyCascadingFields(chain consensus.ChainReader, header *types.Header, parents []*types.Header) error {
+func (sb *backend) verifyCascadingFields(chain consensus.ChainReader, header *types.Header, parents []*types.Header) error {
 	// The genesis block is the always valid dead-end
 	number := header.Number.Uint64()
 	if number == 0 {
@@ -186,7 +190,7 @@ func (sb *simpleBackend) verifyCascadingFields(chain consensus.ChainReader, head
 // concurrently. The method returns a quit channel to abort the operations and
 // a results channel to retrieve the async verifications (the order is that of
 // the input slice).
-func (sb *simpleBackend) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+func (sb *backend) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
 	abort := make(chan struct{})
 	results := make(chan error, len(headers))
 	go func() {
@@ -205,7 +209,7 @@ func (sb *simpleBackend) VerifyHeaders(chain consensus.ChainReader, headers []*t
 
 // VerifyUncles verifies that the given block's uncles conform to the consensus
 // rules of a given engine.
-func (sb *simpleBackend) VerifyUncles(chain consensus.ChainReader, block *types.Block) error {
+func (sb *backend) VerifyUncles(chain consensus.ChainReader, block *types.Block) error {
 	if len(block.Uncles()) > 0 {
 		return errInvalidUncleHash
 	}
@@ -213,7 +217,7 @@ func (sb *simpleBackend) VerifyUncles(chain consensus.ChainReader, block *types.
 }
 
 // verifySigner checks whether the signer is in parent's validator set
-func (sb *simpleBackend) verifySigner(chain consensus.ChainReader, header *types.Header, parents []*types.Header) error {
+func (sb *backend) verifySigner(chain consensus.ChainReader, header *types.Header, parents []*types.Header) error {
 	// Verifying the genesis block is not supported
 	number := header.Number.Uint64()
 	if number == 0 {
@@ -240,7 +244,7 @@ func (sb *simpleBackend) verifySigner(chain consensus.ChainReader, header *types
 }
 
 // verifyCommittedSeals checks whether every committed seal is signed by one of the parent's validators
-func (sb *simpleBackend) verifyCommittedSeals(chain consensus.ChainReader, header *types.Header, parents []*types.Header) error {
+func (sb *backend) verifyCommittedSeals(chain consensus.ChainReader, header *types.Header, parents []*types.Header) error {
 	number := header.Number.Uint64()
 	// We don't need to verify committed seals in the genesis block
 	if number == 0 {
@@ -293,7 +297,7 @@ func (sb *simpleBackend) verifyCommittedSeals(chain consensus.ChainReader, heade
 
 // VerifySeal checks whether the crypto seal on a header is valid according to
 // the consensus rules of the given engine.
-func (sb *simpleBackend) VerifySeal(chain consensus.ChainReader, header *types.Header) error {
+func (sb *backend) VerifySeal(chain consensus.ChainReader, header *types.Header) error {
 	// get parent header and ensure the signer is in parent's validator set
 	number := header.Number.Uint64()
 	if number == 0 {
@@ -309,7 +313,7 @@ func (sb *simpleBackend) VerifySeal(chain consensus.ChainReader, header *types.H
 
 // Prepare initializes the consensus fields of a block header according to the
 // rules of a particular engine. The changes are executed inline.
-func (sb *simpleBackend) Prepare(chain consensus.ChainReader, header *types.Header) error {
+func (sb *backend) Prepare(chain consensus.ChainReader, header *types.Header) error {
 	// unused fields, force to set to empty
 	header.Coinbase = common.Address{}
 	header.Nonce = emptyNonce
@@ -368,7 +372,7 @@ func (sb *simpleBackend) Prepare(chain consensus.ChainReader, header *types.Head
 //
 // Note, the block header and state database might be updated to reflect any
 // consensus rules that happen at finalization (e.g. block rewards).
-func (sb *simpleBackend) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction,
+func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction,
 	uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
 	// No block rewards in Istanbul, so the state remains as is and uncles are dropped
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
@@ -380,7 +384,7 @@ func (sb *simpleBackend) Finalize(chain consensus.ChainReader, header *types.Hea
 
 // Seal generates a new block for the given input block with the local miner's
 // seal place on top.
-func (sb *simpleBackend) Seal(chain consensus.ChainReader, block *types.Block, stop <-chan struct{}) (*types.Block, error) {
+func (sb *backend) Seal(chain consensus.ChainReader, block *types.Block, stop <-chan struct{}) (*types.Block, error) {
 	// update the block header timestamp and signature and propose the block to core engine
 	header := block.Header()
 	number := header.Number.Uint64()
@@ -440,7 +444,7 @@ func (sb *simpleBackend) Seal(chain consensus.ChainReader, block *types.Block, s
 }
 
 // update timestamp and signature of the block based on its number of transactions
-func (sb *simpleBackend) updateBlock(parent *types.Header, block *types.Block) (*types.Block, error) {
+func (sb *backend) updateBlock(parent *types.Header, block *types.Block) (*types.Block, error) {
 	// set block period based the number of tx
 	var period uint64
 	if len(block.Transactions()) == 0 {
@@ -471,7 +475,7 @@ func (sb *simpleBackend) updateBlock(parent *types.Header, block *types.Block) (
 }
 
 // APIs returns the RPC APIs this consensus engine provides.
-func (sb *simpleBackend) APIs(chain consensus.ChainReader) []rpc.API {
+func (sb *backend) APIs(chain consensus.ChainReader) []rpc.API {
 	return []rpc.API{{
 		Namespace: "istanbul",
 		Version:   "1.0",
@@ -481,7 +485,12 @@ func (sb *simpleBackend) APIs(chain consensus.ChainReader) []rpc.API {
 }
 
 // HandleMsg implements consensus.Istanbul.HandleMsg
-func (sb *simpleBackend) HandleMsg(pubKey *ecdsa.PublicKey, data []byte) error {
+func (sb *backend) HandleMsg(pubKey *ecdsa.PublicKey, data []byte) error {
+	sb.coreMu.Lock()
+	defer sb.coreMu.Unlock()
+	if !sb.coreStarted {
+		return istanbul.ErrStoppedEngine
+	}
 	addr := crypto.PubkeyToAddress(*pubKey)
 	// get the latest snapshot
 	curHeader := sb.chain.CurrentHeader()
@@ -503,23 +512,41 @@ func (sb *simpleBackend) HandleMsg(pubKey *ecdsa.PublicKey, data []byte) error {
 }
 
 // NewChainHead implements consensus.Istanbul.NewChainHead
-func (sb *simpleBackend) NewChainHead(block *types.Block) {
+func (sb *backend) NewChainHead(block *types.Block) error {
+	sb.coreMu.Lock()
+	defer sb.coreMu.Unlock()
+	if !sb.coreStarted {
+		return istanbul.ErrStoppedEngine
+	}
 	p, err := sb.Author(block.Header())
 	if err != nil {
 		sb.logger.Error("Failed to get block proposer", "err", err)
-		return
+		return err
 	}
 	go sb.istanbulEventMux.Post(istanbul.FinalCommittedEvent{
 		Proposal: block,
 		Proposer: p,
 	})
+	return nil
 }
 
 // Start implements consensus.Istanbul.Start
-func (sb *simpleBackend) Start(chain consensus.ChainReader, inserter func(block *types.Block) error) error {
+func (sb *backend) Start(chain consensus.ChainReader, inserter func(types.Blocks) (int, error)) error {
+	sb.coreMu.Lock()
+	defer sb.coreMu.Unlock()
+	if sb.coreStarted {
+		return istanbul.ErrStartedEngine
+	}
+
+	// clear previous data
+	sb.proposedBlockHash = common.Hash{}
+	if sb.commitCh != nil {
+		close(sb.commitCh)
+	}
+	sb.commitCh = make(chan *types.Block, 1)
+
 	sb.chain = chain
 	sb.inserter = inserter
-	sb.core = istanbulCore.New(sb, sb.config)
 
 	curHeader := chain.CurrentHeader()
 	lastSequence := new(big.Int).Set(curHeader.Number)
@@ -533,19 +560,29 @@ func (sb *simpleBackend) Start(chain consensus.ChainReader, inserter func(block 
 		lastProposer = p
 	}
 	block := chain.GetBlock(curHeader.Hash(), lastSequence.Uint64())
-	return sb.core.Start(lastSequence, lastProposer, block)
+	if err := sb.core.Start(lastSequence, lastProposer, block); err != nil {
+		return err
+	}
+	sb.coreStarted = true
+	return nil
 }
 
 // Stop implements consensus.Istanbul.Stop
-func (sb *simpleBackend) Stop() error {
-	if sb.core != nil {
-		return sb.core.Stop()
+func (sb *backend) Stop() error {
+	sb.coreMu.Lock()
+	defer sb.coreMu.Unlock()
+	if !sb.coreStarted {
+		return istanbul.ErrStoppedEngine
 	}
+	if err := sb.core.Stop(); err != nil {
+		return err
+	}
+	sb.coreStarted = false
 	return nil
 }
 
 // snapshot retrieves the authorization snapshot at a given point in time.
-func (sb *simpleBackend) snapshot(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) (*Snapshot, error) {
+func (sb *backend) snapshot(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) (*Snapshot, error) {
 	// Search for a snapshot in memory or on disk for checkpoints
 	var (
 		headers []*types.Header
@@ -640,12 +677,23 @@ func sigHash(header *types.Header) (hash common.Hash) {
 
 // ecrecover extracts the Ethereum account address from a signed header.
 func ecrecover(header *types.Header) (common.Address, error) {
+	hash := header.Hash()
+	if addr, ok := recentAddresses.Get(hash); ok {
+		return addr.(common.Address), nil
+	}
+
 	// Retrieve the signature from the header extra-data
 	istanbulExtra, err := types.ExtractIstanbulExtra(header)
 	if err != nil {
 		return common.Address{}, err
 	}
-	return istanbul.GetSignatureAddress(sigHash(header).Bytes(), istanbulExtra.Seal)
+
+	addr, err := istanbul.GetSignatureAddress(sigHash(header).Bytes(), istanbulExtra.Seal)
+	if err != nil {
+		return addr, err
+	}
+	recentAddresses.Add(hash, addr)
+	return addr, nil
 }
 
 // prepareExtra returns a extra-data of the given header and validators
@@ -695,9 +743,15 @@ func writeSeal(h *types.Header, seal []byte) error {
 }
 
 // writeCommittedSeals writes the extra-data field of a block header with given committed seals.
-func writeCommittedSeals(h *types.Header, committedSeals []byte) error {
-	if len(committedSeals)%types.IstanbulExtraSeal != 0 {
+func writeCommittedSeals(h *types.Header, committedSeals [][]byte) error {
+	if len(committedSeals) == 0 {
 		return errInvalidCommittedSeals
+	}
+
+	for _, seal := range committedSeals {
+		if len(seal) != types.IstanbulExtraSeal {
+			return errInvalidCommittedSeals
+		}
 	}
 
 	istanbulExtra, err := types.ExtractIstanbulExtra(h)
@@ -705,11 +759,8 @@ func writeCommittedSeals(h *types.Header, committedSeals []byte) error {
 		return err
 	}
 
-	istanbulExtra.CommittedSeal = make([][]byte, len(committedSeals)/types.IstanbulExtraSeal)
-	for i := 0; i < len(istanbulExtra.CommittedSeal); i++ {
-		istanbulExtra.CommittedSeal[i] = make([]byte, types.IstanbulExtraSeal)
-		copy(istanbulExtra.CommittedSeal[i][:], committedSeals[i*types.IstanbulExtraSeal:])
-	}
+	istanbulExtra.CommittedSeal = make([][]byte, len(committedSeals))
+	copy(istanbulExtra.CommittedSeal, committedSeals)
 
 	payload, err := rlp.EncodeToBytes(&istanbulExtra)
 	if err != nil {

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -41,26 +41,19 @@ import (
 // in this test, we can set n to 1, and it means we can process Istanbul and commit a
 // block by one node. Otherwise, if n is larger than 1, we have to generate
 // other fake events to process Istanbul.
-func newBlockChain(n int) (*core.BlockChain, *simpleBackend) {
+func newBlockChain(n int) (*core.BlockChain, *backend) {
 	genesis, nodeKeys := getGenesisAndKeys(n)
 	eventMux := new(event.TypeMux)
 	memDB, _ := ethdb.NewMemDatabase()
 	config := istanbul.DefaultConfig
 	// Use the first key as private key
-	backend := New(config, eventMux, nodeKeys[0], memDB)
+	b, _ := New(config, eventMux, nodeKeys[0], memDB).(*backend)
 	genesis.MustCommit(memDB)
-	blockchain, err := core.NewBlockChain(memDB, genesis.Config, backend, eventMux, vm.Config{})
+	blockchain, err := core.NewBlockChain(memDB, genesis.Config, b, eventMux, vm.Config{})
 	if err != nil {
 		panic(err)
 	}
-	commitBlock := func(block *types.Block) error {
-		_, err := blockchain.InsertChain([]*types.Block{block})
-		return err
-	}
-	backend.Start(blockchain, commitBlock)
-
-	b, _ := backend.(*simpleBackend)
-
+	b.Start(blockchain, blockchain.InsertChain)
 	snap, err := b.snapshot(blockchain, 0, common.Hash{}, nil)
 	if err != nil {
 		panic(err)
@@ -138,13 +131,13 @@ func makeHeader(parent *types.Block, config *istanbul.Config) *types.Header {
 	return header
 }
 
-func makeBlock(chain *core.BlockChain, engine *simpleBackend, parent *types.Block) *types.Block {
+func makeBlock(chain *core.BlockChain, engine *backend, parent *types.Block) *types.Block {
 	block := makeBlockWithoutSeal(chain, engine, parent)
 	block, _ = engine.Seal(chain, block, nil)
 	return block
 }
 
-func makeBlockWithoutSeal(chain *core.BlockChain, engine *simpleBackend, parent *types.Block) *types.Block {
+func makeBlockWithoutSeal(chain *core.BlockChain, engine *backend, parent *types.Block) *types.Block {
 	header := makeHeader(parent, engine.config)
 	engine.Prepare(chain, header)
 	state, _ := chain.StateAt(parent.Root())
@@ -235,7 +228,7 @@ func TestSealCommittedOtherHash(t *testing.T) {
 			if !ok {
 				t.Errorf("unexpected event comes: %v", reflect.TypeOf(ev.Data))
 			}
-			engine.Commit(otherBlock, []byte{})
+			engine.Commit(otherBlock, [][]byte{})
 		}
 		eventSub.Unsubscribe()
 	}
@@ -572,7 +565,7 @@ func TestWriteCommittedSeals(t *testing.T) {
 	}
 
 	// normal case
-	err := writeCommittedSeals(h, expectedCommittedSeal)
+	err := writeCommittedSeals(h, [][]byte{expectedCommittedSeal})
 	if err != expectedErr {
 		t.Errorf("error mismatch: have %v, want %v", err, expectedErr)
 	}
@@ -588,7 +581,7 @@ func TestWriteCommittedSeals(t *testing.T) {
 
 	// invalid seal
 	unexpectedCommittedSeal := append(expectedCommittedSeal, make([]byte, 1)...)
-	err = writeCommittedSeals(h, unexpectedCommittedSeal)
+	err = writeCommittedSeals(h, [][]byte{unexpectedCommittedSeal})
 	if err != errInvalidCommittedSeals {
 		t.Errorf("error mismatch: have %v, want %v", err, errInvalidCommittedSeals)
 	}

--- a/consensus/istanbul/backend/snapshot_test.go
+++ b/consensus/istanbul/backend/snapshot_test.go
@@ -346,7 +346,7 @@ func TestVoting(t *testing.T) {
 		if tt.epoch != 0 {
 			config.Epoch = tt.epoch
 		}
-		engine := New(config, eventMux, accounts.accounts[tt.validators[0]], db).(*simpleBackend)
+		engine := New(config, eventMux, accounts.accounts[tt.validators[0]], db).(*backend)
 		chain, err := core.NewBlockChain(db, genesis.Config, engine, eventMux, vm.Config{})
 
 		// Assemble a chain of headers from the cast votes

--- a/consensus/istanbul/core/backlog_test.go
+++ b/consensus/istanbul/core/backlog_test.go
@@ -37,7 +37,7 @@ func TestCheckMessage(t *testing.T) {
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(1),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4)),
+		}, newTestValidatorSet(4), common.Hash{}, nil),
 	}
 
 	// invalid view format
@@ -209,7 +209,7 @@ func TestProcessFutureBacklog(t *testing.T) {
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(1),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4)),
+		}, newTestValidatorSet(4), common.Hash{}, nil),
 		state: StateAcceptRequest,
 	}
 	c.subscribeEvents()
@@ -294,7 +294,7 @@ func testProcessBacklog(t *testing.T, msg *message) {
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(1),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4)),
+		}, newTestValidatorSet(4), common.Hash{}, nil),
 	}
 	c.subscribeEvents()
 	defer c.unsubscribeEvents()

--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"bytes"
 	"math/big"
 	"testing"
 
@@ -177,6 +178,9 @@ OUTER:
 				if err != test.expectedErr {
 					t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
 				}
+				if r0.current.IsHashLocked() {
+					t.Errorf("block should not be locked")
+				}
 				continue OUTER
 			}
 		}
@@ -190,7 +194,9 @@ OUTER:
 			if r0.current.Commits.Size() > 2*r0.valSet.F() {
 				t.Errorf("the size of commit messages should be less than %v", 2*r0.valSet.F()+1)
 			}
-
+			if r0.current.IsHashLocked() {
+				t.Errorf("block should not be locked")
+			}
 			continue
 		}
 
@@ -201,13 +207,10 @@ OUTER:
 
 		// check signatures large than 2F+1
 		signedCount := 0
-		signers := make([]common.Address, len(v0.committedSeals[0])/common.AddressLength)
-		for i := 0; i < len(signers); i++ {
-			copy(signers[i][:], v0.committedSeals[0][i*common.AddressLength:])
-		}
+		committedSeals := v0.committedMsgs[0].committedSeals
 		for _, validator := range r0.valSet.List() {
-			for _, signer := range signers {
-				if validator.Address() == signer {
+			for _, seal := range committedSeals {
+				if bytes.Compare(validator.Address().Bytes(), seal[:common.AddressLength]) == 0 {
 					signedCount++
 					break
 				}
@@ -215,6 +218,9 @@ OUTER:
 		}
 		if signedCount <= 2*r0.valSet.F() {
 			t.Errorf("the expected signed count should be larger than %v, but got %v", 2*r0.valSet.F(), signedCount)
+		}
+		if !r0.current.IsHashLocked() {
+			t.Errorf("block should be locked")
 		}
 	}
 }

--- a/consensus/istanbul/core/core_test.go
+++ b/consensus/istanbul/core/core_test.go
@@ -69,14 +69,14 @@ func TestNewRequest(t *testing.T) {
 	}
 
 	for _, backend := range sys.backends {
-		if len(backend.commitMsgs) != 2 {
-			t.Errorf("the number of executed requests mismatch: have %v, want 2", len(backend.commitMsgs))
+		if len(backend.committedMsgs) != 2 {
+			t.Errorf("the number of executed requests mismatch: have %v, want 2", len(backend.committedMsgs))
 		}
-		if !reflect.DeepEqual(request1.Number(), backend.commitMsgs[0].Number()) {
-			t.Errorf("the number of requests mismatch: have %v, want %v", request1.Number(), backend.commitMsgs[0].Number())
+		if !reflect.DeepEqual(request1.Number(), backend.committedMsgs[0].commitProposal.Number()) {
+			t.Errorf("the number of requests mismatch: have %v, want %v", request1.Number(), backend.committedMsgs[0].commitProposal.Number())
 		}
-		if !reflect.DeepEqual(request2.Number(), backend.commitMsgs[1].Number()) {
-			t.Errorf("the number of requests mismatch: have %v, want %v", request2.Number(), backend.commitMsgs[1].Number())
+		if !reflect.DeepEqual(request2.Number(), backend.committedMsgs[1].commitProposal.Number()) {
+			t.Errorf("the number of requests mismatch: have %v, want %v", request2.Number(), backend.committedMsgs[1].commitProposal.Number())
 		}
 	}
 }

--- a/consensus/istanbul/core/events.go
+++ b/consensus/istanbul/core/events.go
@@ -24,3 +24,5 @@ type backlogEvent struct {
 	src istanbul.Validator
 	msg *message
 }
+
+type timeoutEvent struct{}

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -201,6 +201,9 @@ OUTER:
 				if err != test.expectedErr {
 					t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
 				}
+				if r0.current.IsHashLocked() {
+					t.Errorf("block should not be locked")
+				}
 				continue OUTER
 			}
 		}
@@ -213,6 +216,9 @@ OUTER:
 			}
 			if r0.current.Prepares.Size() > 2*r0.valSet.F() {
 				t.Errorf("the size of prepare messages should be less than %v", 2*r0.valSet.F()+1)
+			}
+			if r0.current.IsHashLocked() {
+				t.Errorf("block should not be locked")
 			}
 
 			continue
@@ -245,6 +251,9 @@ OUTER:
 		}
 		if !reflect.DeepEqual(m, expectedSubject) {
 			t.Errorf("subject mismatch: have %v, want %v", m, expectedSubject)
+		}
+		if !r0.current.IsHashLocked() {
+			t.Errorf("block should be locked")
 		}
 	}
 }

--- a/consensus/istanbul/core/preprepare_test.go
+++ b/consensus/istanbul/core/preprepare_test.go
@@ -39,6 +39,7 @@ func TestHandlePreprepare(t *testing.T) {
 		system          *testSystem
 		expectedRequest istanbul.Proposal
 		expectedErr     error
+		existingBlock   bool
 	}{
 		{
 			// normal case
@@ -56,6 +57,7 @@ func TestHandlePreprepare(t *testing.T) {
 			}(),
 			newTestProposal(),
 			nil,
+			false,
 		},
 		{
 			// future message
@@ -84,6 +86,7 @@ func TestHandlePreprepare(t *testing.T) {
 			}(),
 			makeBlock(1),
 			errFutureMessage,
+			false,
 		},
 		{
 			// non-proposer
@@ -105,6 +108,7 @@ func TestHandlePreprepare(t *testing.T) {
 			}(),
 			makeBlock(1),
 			errNotFromProposer,
+			false,
 		},
 		{
 			// ErrInvalidMessage
@@ -124,6 +128,27 @@ func TestHandlePreprepare(t *testing.T) {
 			}(),
 			makeBlock(1),
 			errOldMessage,
+			false,
+		},
+		{
+			// ErrInvalidMessage
+			func() *testSystem {
+				sys := NewTestSystemWithBackend(N, F)
+
+				for i, backend := range sys.backends {
+					c := backend.engine.(*core)
+					c.valSet = backend.peers
+					if i != 0 {
+						c.state = StatePreprepared
+						c.current.SetSequence(big.NewInt(10))
+						c.current.SetRound(big.NewInt(10))
+					}
+				}
+				return sys
+			}(),
+			makeBlock(5), //only height 5 will retrun true on backend.HasBlock, see testSystemBackend.HashBlock
+			nil,
+			true,
 		},
 	}
 
@@ -167,7 +192,7 @@ OUTER:
 				t.Errorf("state mismatch: have %v, want %v", c.state, StatePreprepared)
 			}
 
-			if !reflect.DeepEqual(c.current.Subject().View, curView) {
+			if !test.existingBlock && !reflect.DeepEqual(c.current.Subject().View, curView) {
 				t.Errorf("view mismatch: have %v, want %v", c.current.Subject().View, curView)
 			}
 
@@ -178,16 +203,115 @@ OUTER:
 				t.Errorf("error mismatch: have %v, want nil", err)
 			}
 
-			if decodedMsg.Code != msgPrepare {
-				t.Errorf("message code mismatch: have %v, want %v", decodedMsg.Code, msgPrepare)
+			expectedCode := msgPrepare
+			if test.existingBlock {
+				expectedCode = msgCommit
 			}
+			if decodedMsg.Code != expectedCode {
+				t.Errorf("message code mismatch: have %v, want %v", decodedMsg.Code, expectedCode)
+			}
+
 			var subject *istanbul.Subject
 			err = decodedMsg.Decode(&subject)
 			if err != nil {
 				t.Errorf("error mismatch: have %v, want nil", err)
 			}
-			if !reflect.DeepEqual(subject, c.current.Subject()) {
+			if !test.existingBlock && !reflect.DeepEqual(subject, c.current.Subject()) {
 				t.Errorf("subject mismatch: have %v, want %v", subject, c.current.Subject())
+			}
+
+		}
+	}
+}
+
+func TestHandlePreprepareWithLock(t *testing.T) {
+	N := uint64(4) // replica 0 is primary, it will send messages to others
+	F := uint64(1) // F does not affect tests
+	proposal := newTestProposal()
+	mismatchProposal := makeBlock(10)
+	newSystem := func() *testSystem {
+		sys := NewTestSystemWithBackend(N, F)
+
+		for i, backend := range sys.backends {
+			c := backend.engine.(*core)
+			c.valSet = backend.peers
+			if i != 0 {
+				c.state = StateAcceptRequest
+			}
+			c.roundChangeSet = newRoundChangeSet(c.valSet)
+		}
+		return sys
+	}
+
+	testCases := []struct {
+		system       *testSystem
+		proposal     istanbul.Proposal
+		lockProposal istanbul.Proposal
+	}{
+		{
+			newSystem(),
+			proposal,
+			proposal,
+		},
+		{
+			newSystem(),
+			proposal,
+			mismatchProposal,
+		},
+	}
+
+	for _, test := range testCases {
+		test.system.Run(false)
+		v0 := test.system.backends[0]
+		r0 := v0.engine.(*core)
+		curView := r0.currentView()
+		preprepare := &istanbul.Preprepare{
+			View:     curView,
+			Proposal: test.proposal,
+		}
+		lockPreprepare := &istanbul.Preprepare{
+			View:     curView,
+			Proposal: test.lockProposal,
+		}
+
+		for i, v := range test.system.backends {
+			// i == 0 is primary backend, it is responsible for send preprepare messages to others.
+			if i == 0 {
+				continue
+			}
+
+			c := v.engine.(*core)
+			c.current.SetPreprepare(lockPreprepare)
+			c.current.LockHash()
+			m, _ := Encode(preprepare)
+			_, val := r0.valSet.GetByAddress(v0.Address())
+			if err := c.handlePreprepare(&message{
+				Code:    msgPreprepare,
+				Msg:     m,
+				Address: v0.Address(),
+			}, val); err != nil {
+				t.Errorf("error mismatch: have %v, want nil", err)
+			}
+			if test.proposal == test.lockProposal {
+				if c.state != StatePrepared {
+					t.Errorf("state mismatch: have %v, want %v", c.state, StatePrepared)
+				}
+				if !reflect.DeepEqual(curView, c.currentView()) {
+					t.Errorf("view mismatch: have %v, want %v", c.currentView(), curView)
+				}
+			} else {
+				// Should stay at StateAcceptRequest
+				if c.state != StateAcceptRequest {
+					t.Errorf("state mismatch: have %v, want %v", c.state, StateAcceptRequest)
+				}
+				// Should have triggered a round change
+				expectedView := &istanbul.View{
+					Sequence: curView.Sequence,
+					Round:    big.NewInt(1),
+				}
+				if !reflect.DeepEqual(expectedView, c.currentView()) {
+					t.Errorf("view mismatch: have %v, want %v", c.currentView(), expectedView)
+				}
 			}
 		}
 	}

--- a/consensus/istanbul/core/request_test.go
+++ b/consensus/istanbul/core/request_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -35,7 +36,7 @@ func TestCheckRequestMsg(t *testing.T) {
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(1),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4)),
+		}, newTestValidatorSet(4), common.Hash{}, nil),
 	}
 
 	// invalid request
@@ -90,7 +91,7 @@ func TestStoreRequestMsg(t *testing.T) {
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4)),
+		}, newTestValidatorSet(4), common.Hash{}, nil),
 		pendingRequests:   prque.New(),
 		pendingRequestsMu: new(sync.Mutex),
 	}

--- a/consensus/istanbul/core/roundstate_test.go
+++ b/consensus/istanbul/core/roundstate_test.go
@@ -17,8 +17,11 @@
 package core
 
 import (
+	"math/big"
 	"sync"
+	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 )
 
@@ -31,5 +34,41 @@ func newTestRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet) 
 		Commits:     newMessageSet(validatorSet),
 		Checkpoints: newMessageSet(validatorSet),
 		mu:          new(sync.RWMutex),
+	}
+}
+
+func TestLockHash(t *testing.T) {
+	sys := NewTestSystemWithBackend(1, 0)
+	rs := newTestRoundState(
+		&istanbul.View{
+			Round:    big.NewInt(0),
+			Sequence: big.NewInt(0),
+		},
+		sys.backends[0].peers,
+	)
+	if !common.EmptyHash(rs.GetLockedHash()) {
+		t.Errorf("error mismatch: have %v, want empty", rs.GetLockedHash())
+	}
+	if rs.IsHashLocked() {
+		t.Error("IsHashLocked should return false")
+	}
+
+	// Lock
+	expected := rs.Proposal().Hash()
+	rs.LockHash()
+	if expected != rs.GetLockedHash() {
+		t.Errorf("error mismatch: have %v, want %v", rs.GetLockedHash(), expected)
+	}
+	if !rs.IsHashLocked() {
+		t.Error("IsHashLocked should return true")
+	}
+
+	// Unlock
+	rs.UnlockHash()
+	if !common.EmptyHash(rs.GetLockedHash()) {
+		t.Errorf("error mismatch: have %v, want empty", rs.GetLockedHash())
+	}
+	if rs.IsHashLocked() {
+		t.Error("IsHashLocked should return false")
 	}
 }

--- a/consensus/istanbul/errors.go
+++ b/consensus/istanbul/errors.go
@@ -22,4 +22,8 @@ var (
 	// ErrUnauthorizedAddress is returned when given address cannot be found in
 	// current validator set.
 	ErrUnauthorizedAddress = errors.New("unauthorized address")
+	// ErrStoppedEngine is returned if the engine is stopped
+	ErrStoppedEngine = errors.New("stopped engine")
+	// ErrStartedEngine is returned if the engine is already started
+	ErrStartedEngine = errors.New("started engine")
 )

--- a/consensus/istanbul/events.go
+++ b/consensus/istanbul/events.go
@@ -18,23 +18,32 @@ package istanbul
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
+// ConsensusDataEvent is posted when sending Istanbul consensus data
 type ConsensusDataEvent struct {
-	// target to send message
-	Target common.Address
+	// targets to send message
+	Targets map[common.Address]bool
 	// consensus message data
 	Data []byte
 }
 
+// NewCommittedEvent is posted when I'm not a proposer but
+// a block has been committed from Istanbul consensus.
+type NewCommittedEvent struct{ Block *types.Block }
+
+// RequestEvent is posted to propose a proposal
 type RequestEvent struct {
 	Proposal Proposal
 }
 
+// MessageEvent is posted for Istanbul engine communication
 type MessageEvent struct {
 	Payload []byte
 }
 
+// FinalCommittedEvent is posted when a proposal is committed
 type FinalCommittedEvent struct {
 	Proposal Proposal
 	Proposer common.Address

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -352,6 +352,8 @@ func (s *Ethereum) StartMining(local bool) error {
 			return fmt.Errorf("singer missing: %v", err)
 		}
 		clique.Authorize(eb, wallet.SignHash)
+	} else if istanbul, ok := s.engine.(consensus.Istanbul); ok {
+		istanbul.Start(s.blockchain, s.blockchain.InsertChain)
 	}
 	if local {
 		// If local (CPU) mining is started, we can disable the transaction rejection
@@ -364,7 +366,12 @@ func (s *Ethereum) StartMining(local bool) error {
 	return nil
 }
 
-func (s *Ethereum) StopMining()         { s.miner.Stop() }
+func (s *Ethereum) StopMining() {
+	s.miner.Stop()
+	if istanbul, ok := s.engine.(consensus.Istanbul); ok {
+		istanbul.Stop()
+	}
+}
 func (s *Ethereum) IsMining() bool      { return s.miner.Mining() }
 func (s *Ethereum) Miner() *miner.Miner { return s.miner }
 

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -355,6 +355,9 @@ func (s *Service) login(conn *websocket.Conn) error {
 	if info := infos.Protocols["eth"]; info != nil {
 		network = fmt.Sprintf("%d", info.(*eth.EthNodeInfo).Network)
 		protocol = fmt.Sprintf("eth/%d", eth.ProtocolVersions[0])
+	} else if info := infos.Protocols["istanbul"]; info != nil {
+		network = fmt.Sprintf("%d", info.(*eth.EthNodeInfo).Network)
+		protocol = fmt.Sprintf("istanbul/%d", eth.IstanbulVersion)
 	} else {
 		network = fmt.Sprintf("%d", infos.Protocols["les"].(*eth.EthNodeInfo).Network)
 		protocol = fmt.Sprintf("les/%d", les.ProtocolVersions[0])


### PR DESCRIPTION
* consensus/istanbul: handle future preprepare
* consensus/istanbul: handle request timeout in evnet loop
* consensus, eth: start/stop core engine while start/stop mining
* eth, ethstats: fix crash while reporting to ethstats
* consensus/istanbul, miner: add new event to trigger new block creation
* eth, consensus/istanbul: improve sending messages
* consensus/istanbul: stop future preprepare timer while stop core
* consensus/istanbul: add cache in ecrecover()