### PR TITLE
consensus/istanbul: send PREPARE instead of COMMIT after receiving PREPREPARE when we have locked proposal

### DIFF
--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -58,19 +58,6 @@ func (c *core) handlePreprepare(msg *message, src istanbul.Validator) error {
 	// Ensure we have the same view with the preprepare message
 	// If it is old message, see if we need to broadcast COMMIT
 	if err := c.checkMessage(msgPreprepare, preprepare.View); err != nil {
-		if err == errOldMessage {
-			// Get validator set for the given proposal
-			valSet := c.backend.ParentValidators(preprepare.Proposal).Copy()
-			previousProposer := c.backend.GetProposer(preprepare.Proposal.Number().Uint64() - 1)
-			valSet.CalcProposer(previousProposer, preprepare.View.Round.Uint64())
-			// Broadcast COMMIT if it is an existing block
-			// 1. The proposer needs to be a proposer matches the given (Sequence + Round)
-			// 2. The given block must exist
-			if valSet.IsProposer(src.Address()) && c.backend.HasBlock(preprepare.Proposal.Hash(), preprepare.Proposal.Number()) {
-				c.sendCommitForOldBlock(preprepare.View, preprepare.Proposal.Hash())
-				return nil
-			}
-		}
 		return err
 	}
 

--- a/consensus/istanbul/core/preprepare_test.go
+++ b/consensus/istanbul/core/preprepare_test.go
@@ -111,7 +111,7 @@ func TestHandlePreprepare(t *testing.T) {
 			false,
 		},
 		{
-			// ErrInvalidMessage
+			// errOldMessage
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
@@ -129,26 +129,6 @@ func TestHandlePreprepare(t *testing.T) {
 			makeBlock(1),
 			errOldMessage,
 			false,
-		},
-		{
-			// ErrInvalidMessage
-			func() *testSystem {
-				sys := NewTestSystemWithBackend(N, F)
-
-				for i, backend := range sys.backends {
-					c := backend.engine.(*core)
-					c.valSet = backend.peers
-					if i != 0 {
-						c.state = StatePreprepared
-						c.current.SetSequence(big.NewInt(10))
-						c.current.SetRound(big.NewInt(10))
-					}
-				}
-				return sys
-			}(),
-			makeBlock(5), //only height 5 will retrun true on backend.HasBlock, see testSystemBackend.HashBlock
-			nil,
-			true,
 		},
 	}
 
@@ -293,8 +273,8 @@ func TestHandlePreprepareWithLock(t *testing.T) {
 				t.Errorf("error mismatch: have %v, want nil", err)
 			}
 			if test.proposal == test.lockProposal {
-				if c.state != StatePrepared {
-					t.Errorf("state mismatch: have %v, want %v", c.state, StatePrepared)
+				if c.state != StatePreprepared {
+					t.Errorf("state mismatch: have %v, want %v", c.state, StatePreprepared)
 				}
 				if !reflect.DeepEqual(curView, c.currentView()) {
 					t.Errorf("view mismatch: have %v, want %v", c.currentView(), curView)


### PR DESCRIPTION
send PREPARE instead of COMMIT after receiving PREPREPARE when we have locked proposal